### PR TITLE
Fix `getDTVolumes` loop

### DIFF
--- a/util/query.py
+++ b/util/query.py
@@ -233,7 +233,7 @@ def getDTVolumes(
             offset,
             chunk_size,
         )
-        offset += 1000
+        offset += chunk_size
         result = submitQuery(query, chainID)
         new_orders = result["data"]["orders"]
         if new_orders == []:


### PR DESCRIPTION
Fixes #131

Changes proposed in this PR:

- [Fix getDTVolumes loop](https://github.com/oceanprotocol/df-py/commit/6efd1817537f6747308c037d06b0e6107f857d4f)
- [Update getAllPools](https://github.com/oceanprotocol/df-py/commit/a8d8bd8b2322d417f14960fa29d16c94156872c6)
- Use a while loop and break when there are no orders left.