### PR TITLE
Test claim and restake

### DIFF
--- a/util/test/test_DFRewards.py
+++ b/util/test/test_DFRewards.py
@@ -3,7 +3,7 @@ from enforce_typing import enforce_types
 
 from util.constants import BROWNIE_PROJECT as B
 from util.base18 import toBase18
-from util import networkutil, oceanutil
+from util import networkutil, oceanutil, oceantestutil
 
 accounts, a1, a2, a3 = None, None, None, None
 
@@ -212,6 +212,66 @@ def test_strategies():
 
     # strategy balance increases
     assert TOK.balanceOf(df_strategy) == 60
+
+
+@enforce_types
+def test_claim_and_restake():
+    address_file = networkutil.chainIdToAddressFile(networkutil.DEV_CHAINID)
+    oceanutil.recordDeployedContracts(address_file)
+    OCEAN = oceanutil.OCEANtoken()
+
+    df_rewards = B.DFRewards.deploy({"from": accounts[0]})
+    df_strategy = B.DFStrategyV1.deploy(df_rewards.address, {"from": accounts[0]})
+    df_rewards.addStrategy(df_strategy.address)
+
+    tos = [a1]
+    values = [toBase18(50.0)]
+    OCEAN.approve(df_rewards, sum(values), {"from": accounts[0]})
+    df_rewards.allocate(tos, values, OCEAN.address, {"from": accounts[0]})
+
+    assert df_rewards.claimable(a1, OCEAN.address) == toBase18(50.0)
+
+    pools = []
+    amounts = []
+    POOL_COUNT = 10
+
+    for _ in range(POOL_COUNT):
+        (_, pool) = oceantestutil.randomDeployPool(accounts[0], OCEAN)
+        pools.append(pool)
+        amounts.append(toBase18(50 / POOL_COUNT) - 1)
+
+    for pool in pools:
+        assert pool.balanceOf(accounts[1]) == 0
+
+    with brownie.reverts("Not enough rewards"):
+        # Cannot claim what you don't have
+        df_strategy.claimAndStake(
+            OCEAN.address,
+            [pools[0].address],
+            [toBase18(100.0)],
+            {"from": accounts[1]},
+        )
+    with brownie.reverts("Lengths must match"):
+        # Cannot claim what you don't have
+        df_strategy.claimAndStake(
+            OCEAN.address,
+            [pools[0].address],
+            [5, 5, 5],
+            {"from": accounts[1]},
+        )
+
+    print(amounts)
+
+    df_strategy.claimAndStake(
+        OCEAN.address,
+        [pool.address for pool in pools],
+        amounts,
+        {"from": accounts[1]},
+    )
+
+    for pool in pools:
+        assert pool.balanceOf(accounts[1]) > 0
+    assert df_rewards.claimable(a1, OCEAN.address) == 0
 
 
 @enforce_types


### PR DESCRIPTION
Fixes #134

Changes proposed in this PR:

- [Add test_claim_and_restake](https://github.com/oceanprotocol/df-py/commit/2cb075a9c9067ed137a563fa0c90136558e0ee0d)

I noticed that in the smart contract we're checking:
```solidity
require(
      dfrewards.claimable(msg.sender, tokenAddress) > totalAmount,
      "Not enough rewards"
);
```
It should have been `>=` instead. It's not a big problem, we can subtract 1 from the total reward amount and it should work.