### PR TITLE
Smart remove allocation

### DIFF
--- a/contracts/ve/veAllocate.sol
+++ b/contracts/ve/veAllocate.sol
@@ -24,6 +24,16 @@ contract veAllocate {
         return veAllocation[_address][_id];
     }
 
+    function getTotalAllocation(address _address)
+        public
+        view
+        returns (uint256)
+    {
+        // string is {DT Address}-{chain id}
+        // returns the allocation perc for given address
+        return _totalAllocation[_address];
+    }
+
     function setAllocation(uint256 amount, string calldata _id) external {
         require(bytes(_id).length < 50, "Id too long");
         require(amount <= 1000, "BM");

--- a/util/test/veOcean/test_allocate_dt.py
+++ b/util/test/veOcean/test_allocate_dt.py
@@ -14,28 +14,24 @@ def test_allocate():
     """sending native tokens to dfrewards contract should revert"""
 
     veAllocate.setAllocation(100, "test", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 100
-    assert allocation[1][0] == "test"
-    assert allocation[2][0] == 100
+    allocation = veAllocate.getTotalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][0] == "test"
+    assert allocation[1][0] == 100
 
     veAllocate.setAllocation(25, "test2", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 125
-    assert allocation[1][1] == "test2"
-    assert allocation[2][1] == 25
+    allocation = veAllocate.getTotalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][1] == "test2"
+    assert allocation[1][1] == 25
 
     veAllocate.setAllocation(50, "test3", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 175
-    assert allocation[1][2] == "test3"
-    assert allocation[2][2] == 50
+    allocation = veAllocate.getTotalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][2] == "test3"
+    assert allocation[1][2] == 50
 
-    veAllocate.setAllocation(0, "test3", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 125
-    assert allocation[1][2] == "test3"
-    assert allocation[2][2] == 0
+    veAllocate.setAllocation(0, "test", {"from": accounts[0]})
+    allocation = veAllocate.getTotalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][0] == "test3"
+    assert allocation[1][0] == 50
 
 
 @enforce_types

--- a/util/test/veOcean/test_allocate_dt.py
+++ b/util/test/veOcean/test_allocate_dt.py
@@ -13,29 +13,36 @@ veAllocate = None
 def test_allocate():
     """sending native tokens to dfrewards contract should revert"""
 
-    veAllocate.allocate(100, "test", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 100
-    assert allocation[1][0] == "test"
-    assert allocation[2][0] == 100
+    id1 = "23Bf9415c804fd777245CC2f7D9f141dd0AC34Ca-1"
+    id2 = "9c0F7CEda17246514dBA4d65dCD93A37662B3bBa-137"
+    id3 = "e447023dAC7A7DEB2e58d9b2f9b439D54e8Aa800-1"
 
-    veAllocate.allocate(25, "test2", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 125
-    assert allocation[1][1] == "test2"
-    assert allocation[2][1] == 25
+    veAllocate.allocate(100, id1, {"from": accounts[0]})
+    allocation = veAllocate.totalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][0] == id1
+    assert allocation[1][0] == 100
 
-    veAllocate.allocate(50, "test3", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 175
-    assert allocation[1][2] == "test3"
-    assert allocation[2][2] == 50
+    veAllocate.allocate(25, id2, {"from": accounts[0]})
+    allocation = veAllocate.totalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][1] == id2
+    assert allocation[1][1] == 25
 
-    veAllocate.removeAllocation(50, "test3", {"from": accounts[0]})
-    allocation = veAllocate.totalAllocation(accounts[0].address)
-    assert allocation[0] == 125
-    assert allocation[1][2] == "test3"
-    assert allocation[2][2] == 0
+    veAllocate.allocate(50, id3, {"from": accounts[0]})
+    allocation = veAllocate.totalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][2] == id3
+    assert allocation[1][2] == 50
+
+    # remove 50 tokens from id1
+    veAllocate.removeAllocation(50, id1, {"from": accounts[0]})
+    allocation = veAllocate.totalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][0] == id1
+    assert allocation[1][0] == 50
+
+    # remove the remaining 50 tokens from id1
+    veAllocate.removeAllocation(50, id1, {"from": accounts[0]})
+    allocation = veAllocate.totalAllocation(accounts[0].address, 100, 0)
+    assert allocation[0][0] == id3  # should swap with last one
+    assert allocation[1][0] == 50  # should swap with last one
 
 
 @enforce_types


### PR DESCRIPTION
Changes proposed in this PR:

- Removing 100% allocation swaps the last element with the element id. Thus there won't be records with zero allocation.
- Added `limit` and `skip` params to `totalAllocation` function.
- Added new mapping `idToAllocation`.
- Added tests.

This might be a waste of gas, but the best solution I found in case we want to read data directly from the chain.