### PR TITLE
Update veAllocate to max 100 points across all dataNFT

### DIFF
--- a/contracts/ve/veAllocate.sol
+++ b/contracts/ve/veAllocate.sol
@@ -38,7 +38,7 @@ contract veAllocate {
             amount -
             veAllocation[msg.sender][nft][chainId];
 
-        require(_totalAllocation[msg.sender] <= 1000, "Max Allocation");
+        require(_totalAllocation[msg.sender] <= 10000, "Max Allocation");
         veAllocation[msg.sender][nft][chainId] = amount;
         emit AllocationSet(msg.sender, nft, chainId, amount);
     }

--- a/util/test/veOcean/test_allocate_dt.py
+++ b/util/test/veOcean/test_allocate_dt.py
@@ -44,7 +44,7 @@ def test_events():
 def test_max_allocation():
     nftaddr = accounts[1].address
     with brownie.reverts("Max Allocation"):
-        veAllocate.setAllocation(1001, nftaddr, 1, {"from": accounts[0]})
+        veAllocate.setAllocation(10001, nftaddr, 1, {"from": accounts[0]})
 
 
 @enforce_types


### PR DESCRIPTION
Fixes #252 

Changes proposed in this PR:

- Update `veAllocate` to max 100**0** points across all dataNFT

I set the max to 1000, so we can have more precision.