### PR TITLE
bump to contracts 1.1.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
             done
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
         env:
-          CONTRACTS_VERSION: v1.1.1
+          CONTRACTS_VERSION: v1.1.2
           SUBGRAPH_VERSION: veAllocate
           
       - name: Install dependencies


### PR DESCRIPTION
Closes #264 
Changes proposed in this PR:

- bump to contracts 1.1.2 (subgraph is already updated in https://github.com/oceanprotocol/ocean-subgraph/pull/490/commits/ef2b91d2ce5dc61d91b65c3d124fc312bc097f7e)
