### PR TITLE
Test edge cases in reward calculation function

### DIFF
--- a/util/calcrewards.py
+++ b/util/calcrewards.py
@@ -36,6 +36,13 @@ def calcRewards(
       rewardsperlp -- dict of [chainID][LP_addr] : TOKEN_float -- reward per chain/LP
       rewardsinfo -- dict of [chainID][nft_addr][LP_addr] : TOKEN_float -- reward per chain/LP
     """
+
+    if len(allocations) == 0:
+        raise ValueError("No allocations provided")
+
+    if len(veBalances) == 0:
+        raise ValueError("No veBalances provided")
+
     (allocations, nftvols, rates) = cleancase.modTuple(allocations, nftvols, rates)
     (allocations, nftvols) = approvedfilter.modTuple(
         approved_token_addrs, allocations, nftvols

--- a/util/test/test_calcrewards.py
+++ b/util/test/test_calcrewards.py
@@ -599,3 +599,29 @@ def test_no_vebals():
 
     assert str(err.value) == "No veBalances provided"
 
+
+@enforce_types
+def test_no_allocations():
+    # LP2 has allocation but has no ve balance
+    # LP1 has ve balance but no allocation
+    # calcRewards should return an empty dict
+    allocations = {}
+    vebals = {
+        LP1: 1.0,
+    }
+    nftvols = {C1: {OCN_ADDR: {LP1: 1.0, LP2: 1.0}}}
+
+    # should raise valueError "no allocations"
+    with pytest.raises(ValueError) as err:
+        err = calcRewards(
+            allocations,
+            vebals,
+            nftvols,
+            APPROVED_TOKEN_ADDRS,
+            SYMBOLS,
+            RATES,
+            10000.0,
+            "OCEAN",
+        )
+
+    assert str(err.value) == "No allocations provided"

--- a/util/test/test_calcrewards.py
+++ b/util/test/test_calcrewards.py
@@ -574,3 +574,28 @@ def test_bound_APY_two_nfts__high_stake__one_nft_dominates_DCV():
     # LP2 reward swamps LP1 because LP2's stake * DCV is way higher; it's *not* bounded by low stake
     assert rewardsperlp[C1] == {LP1: 1.0, LP2: 9999.0}
     assert rewardsinfo[C1] == {PA: {LP1: 1.0}, PB: {LP2: 9999.0}}
+
+
+@enforce_types
+def test_no_vebals():
+    # LP2 has allocation, no ve balances
+    # LP1 has ve balance but no allocation
+    # calcRewards should return an empty dict
+    allocations = {C1: {PB: {LP2: 1e6}}}
+    vebals = {}
+    nftvols = {C1: {OCN_ADDR: {LP1: 1.0, LP2: 1.0}}}
+
+    with pytest.raises(ValueError) as err:
+        calcRewards(
+            allocations,
+            vebals,
+            nftvols,
+            APPROVED_TOKEN_ADDRS,
+            SYMBOLS,
+            RATES,
+            10000.0,
+            "OCEAN",
+        )
+
+    assert str(err.value) == "No veBalances provided"
+

--- a/util/test/test_calcrewards.py
+++ b/util/test/test_calcrewards.py
@@ -577,6 +577,32 @@ def test_bound_APY_two_nfts__high_stake__one_nft_dominates_DCV():
 
 
 @enforce_types
+def test_alloc_vebal_mismatch():
+    # LP2 has allocation but has no ve balance
+    # LP1 has ve balance but no allocation
+    # calcRewards should return an empty dict
+    allocations = {C1: {PB: {LP2: 1e6}}}
+    vebals = {
+        LP1: 1.0,
+    }
+    nftvols = {C1: {OCN_ADDR: {LP1: 1.0, LP2: 1.0}}}
+
+    rewards_avail_OCEAN = 10000.0
+    rewardsperlp, _ = calcRewards(
+        allocations,
+        vebals,
+        nftvols,
+        APPROVED_TOKEN_ADDRS,
+        SYMBOLS,
+        RATES,
+        rewards_avail_OCEAN,
+        "OCEAN",
+    )
+
+    assert rewardsperlp == {}
+
+
+@enforce_types
 def test_no_vebals():
     # LP2 has allocation, no ve balances
     # LP1 has ve balance but no allocation


### PR DESCRIPTION
Fixes #278

Added tests for the following cases:
- Empty allocations array. Excepted: (Raise error)
- Empty vebals array. Excepted: (Raise error)
- Allocations & vebals mismatch. Excepted: (No rewards)