### PR TITLE
Make sure estimateClaim is accurate

### DIFF
--- a/contracts/ve/FeeEstimate.vy
+++ b/contracts/ve/FeeEstimate.vy
@@ -95,6 +95,7 @@ def estimateClaim(addr: address) -> uint256:
     max_user_epoch: uint256 = VotingEscrow(self.voting_escrow).user_point_epoch(addr)
     _start_time: uint256 = FeeDistributor(self.fee_distributor).start_time()
     _last_token_time: uint256 = FeeDistributor(self.fee_distributor).last_token_time()
+    # Round down to weeks
     _last_token_time = _last_token_time / WEEK * WEEK
     
     if max_user_epoch == 0:

--- a/contracts/ve/FeeEstimate.vy
+++ b/contracts/ve/FeeEstimate.vy
@@ -95,7 +95,8 @@ def estimateClaim(addr: address) -> uint256:
     max_user_epoch: uint256 = VotingEscrow(self.voting_escrow).user_point_epoch(addr)
     _start_time: uint256 = FeeDistributor(self.fee_distributor).start_time()
     _last_token_time: uint256 = FeeDistributor(self.fee_distributor).last_token_time()
-
+    _last_token_time = _last_token_time / WEEK * WEEK
+    
     if max_user_epoch == 0:
         # No lock = no fees
         return 0

--- a/contracts/ve/FeeEstimate.vy
+++ b/contracts/ve/FeeEstimate.vy
@@ -99,9 +99,9 @@ def estimateClaim(addr: address) -> uint256:
     # if checkpoints are missing, them we cannot have an accurate estimate
     # veFeeDistributor can do the checks, but requires tx and not just some call functions
     if block.timestamp >= FeeDistributor(self.fee_distributor).time_cursor():
-        return 0
+        raise("Call checkpoint function")
     if block.timestamp > _last_token_time + TOKEN_CHECKPOINT_DEADLINE:
-        return 0
+        raise("Call checkpoint function")
 
     # Round down to weeks
     _last_token_time = _last_token_time / WEEK * WEEK

--- a/contracts/ve/FeeEstimate.vy
+++ b/contracts/ve/FeeEstimate.vy
@@ -23,6 +23,7 @@ interface FeeDistributor:
     def user_epoch_of(addr: address) -> uint256: view
     def tokens_per_week(week: uint256) -> uint256: view
     def ve_supply(week: uint256) -> uint256: view
+    def TOKEN_CHECKPOINT_DEADLINE() -> uint256: view
 
 struct Point:
     bias: int128
@@ -91,10 +92,17 @@ def estimateClaim(addr: address) -> uint256:
     # Minimal user_epoch is 0 (if user had no point)
     user_epoch: uint256 = 0
     to_distribute: uint256 = 0
-
+    _last_token_time: uint256 = FeeDistributor(self.fee_distributor).last_token_time()
     max_user_epoch: uint256 = VotingEscrow(self.voting_escrow).user_point_epoch(addr)
     _start_time: uint256 = FeeDistributor(self.fee_distributor).start_time()
-    _last_token_time: uint256 = FeeDistributor(self.fee_distributor).last_token_time()
+    
+    # if checkpoints are missing, them we cannot have an accurate estimate
+    # veFeeDistributor can do the checks, but requires tx and not just some call functions
+    if block.timestamp >= FeeDistributor(self.fee_distributor).time_cursor():
+        return 0
+    if block.timestamp > _last_token_time + TOKEN_CHECKPOINT_DEADLINE:
+        return 0
+
     # Round down to weeks
     _last_token_time = _last_token_time / WEEK * WEEK
     

--- a/util/test/veOcean/test_estimateclaim.py
+++ b/util/test/veOcean/test_estimateclaim.py
@@ -159,9 +159,7 @@ def test_rewards():
 
         print("end week********\n")
 
-    # uncomment the line below to see all debug logs
-    assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
-
+    
 
 @enforce_types
 def setup_function():

--- a/util/test/veOcean/test_estimateclaim.py
+++ b/util/test/veOcean/test_estimateclaim.py
@@ -159,7 +159,6 @@ def test_rewards():
 
         print("end week********\n")
 
-    
 
 @enforce_types
 def setup_function():

--- a/util/test/veOcean/test_estimateclaim.py
+++ b/util/test/veOcean/test_estimateclaim.py
@@ -76,7 +76,11 @@ def test_rewards():
         OCEAN.transfer(
             fee_distributor.address, toBase18(opffees), {"from": accounts[0]}
         )
+        with brownie.reverts("Call checkpoint function"):
+            fee_estimate.estimateClaim(alice)
         fee_distributor.checkpoint_total_supply()
+        with brownie.reverts("Call checkpoint function"):
+            fee_estimate.estimateClaim(alice)
         fee_distributor.checkpoint_token()
         epoch = veOCEAN.epoch()
         print(f"\t veOcean epoch: {epoch}")

--- a/util/test/veOcean/test_estimateclaim.py
+++ b/util/test/veOcean/test_estimateclaim.py
@@ -160,7 +160,7 @@ def test_rewards():
         print("end week********\n")
 
     # uncomment the line below to see all debug logs
-    # assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
+    assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
 
 
 @enforce_types

--- a/util/test/veOcean/test_fee_dist.py
+++ b/util/test/veOcean/test_fee_dist.py
@@ -62,11 +62,15 @@ def test_alice_locks_tokens_after():
     chain.mine()
 
     before_f = OCEAN.balanceOf(fee_distributor)
-    estimate = fee_estimate.estimateClaim(alice)
+    try:
+        estimate = fee_estimate.estimateClaim(alice)
+    except:
+        estimate = None
     fee_distributor.claim({"from": alice})  # alice claims rewards
     after_f = OCEAN.balanceOf(fee_distributor)
     assert abs(after_f - before_f) < toBase18(0.01)
-    assert abs(after_f - before_f) == estimate
+    if estimate is not None:
+        assert abs(after_f - before_f) == estimate
 
 
 @enforce_types
@@ -113,7 +117,11 @@ def test_alice_locks_tokens_exact():
     fee_distributor.checkpoint_total_supply()
 
     alice_before = OCEAN.balanceOf(alice)
-    estimate = fee_estimate.estimateClaim(alice)
+    try:
+        estimate = fee_estimate.estimateClaim(alice)
+    except:
+        estimate = None
+
     fee_distributor.claim({"from": alice})  # alice claims rewards
     alice_after = OCEAN.balanceOf(alice)
 
@@ -169,14 +177,18 @@ def test_alice_claims_after_lock_ends():
 
     before = OCEAN.balanceOf(fee_distributor)
     alice_balance_ocean_before = OCEAN.balanceOf(alice)
-    estimate = fee_estimate.estimateClaim(alice)
+    try:
+        estimate = fee_estimate.estimateClaim(alice)
+    except:
+        estimate = None
     fee_distributor.claim({"from": alice})  # alice claims rewards
     alice_balance_ocean_after = OCEAN.balanceOf(alice)
 
     assert (before - TA) < 10
     assert alice_balance_ocean_after > alice_balance_ocean_before
     assert abs(alice_balance_ocean_after - TA * 2) < 10
-    assert (alice_balance_ocean_after - alice_balance_ocean_before) == estimate
+    if estimate is not None:
+        assert (alice_balance_ocean_after - alice_balance_ocean_before) == estimate
 
 
 @enforce_types

--- a/util/test/veOcean/test_rewards.py
+++ b/util/test/veOcean/test_rewards.py
@@ -1,0 +1,147 @@
+import brownie
+from enforce_typing import enforce_types
+import pytest
+
+from util import networkutil, oceanutil
+from util.constants import BROWNIE_PROJECT as B
+from util.base18 import toBase18, fromBase18
+
+accounts = None
+alice = None
+bob = None
+veOCEAN = None
+OCEAN = None
+WEEK = 7 * 86400
+MAXTIME = 4 * 365 * 86400  # 4 years
+chain = brownie.network.chain
+TA = toBase18(10000.0)
+DAY = 86400
+
+
+@enforce_types
+def test_rewards():
+    """Test rewards, claims & feeEstimator"""
+
+    fee_distributor = B.FeeDistributor.deploy(
+        veOCEAN.address,
+        chain.time(),
+        OCEAN.address,
+        accounts[0].address,
+        accounts[0].address,
+        {
+            "from": accounts[0],
+        },
+    )
+    fee_estimate = B.FeeEstimate.deploy(
+        veOCEAN.address,
+        fee_distributor.address,
+        {
+            "from": accounts[0],
+        },
+    )
+    #weekly , OPF adds 10 Ocean as rewards
+    opffees = 10.0
+    t0 = chain.time()
+
+    # each actor adds 100 Ocean tokens in week 0
+    OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": alice})
+    OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": bob})
+    OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": charlie})
+    OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": david})
+    
+    # each actor has different lock times
+    alice_lock_time = t0 + 4 * 365 * 86400 - 15*60 # 4 years - 15 mins
+    bob_lock_time = t0 + 2 * 365 * 86400 - 15*60 # 2 years - 15 mins
+    charlie_lock_time = t0 + 1 * 365 * 86400 - 15*60 # 1 year - 15 mins
+    david_lock_time = t0 + 3 * 365 * 86400 - 15*60 # 3 year - 15 mins
+    veOCEAN.create_lock(toBase18(100.0), alice_lock_time, {"from": alice})
+    veOCEAN.create_lock(toBase18(100.0), bob_lock_time, {"from": bob})
+    veOCEAN.create_lock(toBase18(100.0), charlie_lock_time, {"from": charlie})
+    veOCEAN.create_lock(toBase18(100.0), david_lock_time, {"from": david})
+    
+    #wait 2 days and OPF adds rewards
+    chain.sleep(DAY)
+    chain.mine()
+    chain.sleep(DAY)
+    chain.mine()
+    OCEAN.transfer(fee_distributor.address, toBase18(opffees), {"from": accounts[0]})
+    fee_distributor.checkpoint_token()
+    fee_distributor.checkpoint_total_supply()
+    # and sleep one more day
+    chain.sleep(DAY)
+    chain.mine()
+
+    alice_total_withdraws=0
+    bob_total_withdraws=0
+    charlie_total_withdraws=0
+    david_total_withdraws=0
+    rangeus=52  # we will run the tests for 1 year
+    for i in range(rangeus):  
+        print(f"\nNew week****{i}****")
+        chain.sleep(WEEK)
+        chain.mine()
+        
+        print(f"\t OPF is adding {opffees} as rewards")
+        OCEAN.transfer(fee_distributor.address, toBase18(opffees), {"from": accounts[0]})
+        fee_distributor.checkpoint_token()
+        fee_distributor.checkpoint_total_supply()
+        
+        
+        # compute estimateClaim
+        estimateAlice1w = fromBase18(fee_estimate.estimateClaim(alice))
+        estimateBob1w = fromBase18(fee_estimate.estimateClaim(bob))
+        estimateCharlie1w = fromBase18(fee_estimate.estimateClaim(charlie))
+        estimateDavid1w = fromBase18(fee_estimate.estimateClaim(david))
+        print(f"\t Alice estimates claim:{estimateAlice1w}")
+        
+        
+        # Alice claims every week
+        initialAlice=fromBase18(OCEAN.balanceOf(alice))
+        fee_distributor.claim({"from": alice})  # alice claims rewards
+        afterAlice=fromBase18(OCEAN.balanceOf(alice))
+        alice_claimed = afterAlice-initialAlice
+        alice_total_withdraws=alice_total_withdraws+alice_claimed
+        #compare it
+        print(f"\t Alice claimed:{alice_claimed}")
+        assert alice_claimed == pytest.approx(estimateAlice1w,0.0000001)
+
+        # Bob claims every 2 weeks
+        print(f"\t Bob estimates claim:{estimateBob1w}")
+        if i%2==0:
+            initialBob=fromBase18(OCEAN.balanceOf(bob))
+            fee_distributor.claim({"from": bob})  # bob claims rewards
+            afterBob=fromBase18(OCEAN.balanceOf(bob))
+            bob_claimed = afterBob-initialBob
+            bob_total_withdraws=bob_total_withdraws+bob_claimed
+            #compare it
+            print(f"\t Bob claimed:{bob_claimed}")
+            assert bob_claimed == pytest.approx(estimateBob1w,0.0000001)
+
+        print("end week********\n")
+
+    assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
+
+    
+
+
+@enforce_types
+def setup_function():
+    global accounts, alice, bob, charlie, david, veOCEAN, OCEAN, feeDistributor
+    networkutil.connect(networkutil.DEV_CHAINID)
+    oceanutil.recordDevDeployedContracts()
+    accounts = brownie.network.accounts
+
+    alice = accounts.add()
+    bob = accounts.add()
+    charlie = accounts.add()
+    david = accounts.add()
+
+    OCEAN = oceanutil.OCEANtoken()
+    veOCEAN = B.veOcean.deploy(
+        OCEAN.address, "veOCEAN", "veOCEAN", "0.1.0", {"from": alice}
+    )
+
+    OCEAN.transfer(alice, TA, {"from": accounts[0]})
+    OCEAN.transfer(bob, TA, {"from": accounts[0]})
+    OCEAN.transfer(charlie, TA, {"from": accounts[0]})
+    OCEAN.transfer(david, TA, {"from": accounts[0]})

--- a/util/test/veOcean/test_rewards.py
+++ b/util/test/veOcean/test_rewards.py
@@ -41,42 +41,46 @@ def test_rewards():
             "from": accounts[0],
         },
     )
-    #weekly , OPF adds 10 Ocean as rewards
+    # weekly , OPF adds 10 Ocean as rewards
     opffees = 10.0
     t0 = chain.time()
 
     # each actor adds 100 Ocean tokens in week 0
     OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": alice})
     OCEAN.approve(veOCEAN.address, toBase18(100.0), {"from": bob})
-    
+
     # each actor has different lock times
-    alice_lock_time = t0 + 4 * 365 * 86400 - 15*60 # 4 years - 15 mins
-    bob_lock_time = t0 + 2 * 365 * 86400 - 15*60 # 2 years - 15 mins
+    alice_lock_time = t0 + 4 * 365 * 86400 - 15 * 60  # 4 years - 15 mins
+    bob_lock_time = t0 + 2 * 365 * 86400 - 15 * 60  # 2 years - 15 mins
     veOCEAN.create_lock(toBase18(100.0), alice_lock_time, {"from": alice})
     veOCEAN.create_lock(toBase18(100.0), bob_lock_time, {"from": bob})
-    
-    alice_total_withdraws=0
-    bob_total_withdraws=0
-    rangeus=52  # we will run the tests for 52 weeks
-    sleep_amount=DAY*7
-    chain_time=datetime.utcfromtimestamp(chain.time()).strftime('%Y-%m-%d %H:%M:%S')
+
+    alice_total_withdraws = 0
+    bob_total_withdraws = 0
+    rangeus = 52  # we will run the tests for 52 weeks
+    sleep_amount = DAY * 7
+    chain_time = datetime.utcfromtimestamp(chain.time()).strftime("%Y-%m-%d %H:%M:%S")
     print(f"Chain_time: {chain_time}")
-    for i in range(rangeus):  
-        total_days=i*sleep_amount/DAY
+    for i in range(rangeus):
+        total_days = i * sleep_amount / DAY
         print(f"\nNew iteration****{i}****  Total days pased:{total_days}")
         chain.sleep(sleep_amount)
         chain.mine()
-        chain_time=datetime.utcfromtimestamp(chain.time()).strftime('%Y-%m-%d %H:%M:%S')
+        chain_time = datetime.utcfromtimestamp(chain.time()).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
         print(f"\t Chain_time after sleep: {chain_time}")
-        
-        #every week, OPC adds rewards
+
+        # every week, OPC adds rewards
         print(f"\t OPF is adding {opffees} OCEAN as rewards")
-        OCEAN.transfer(fee_distributor.address, toBase18(opffees), {"from": accounts[0]})
+        OCEAN.transfer(
+            fee_distributor.address, toBase18(opffees), {"from": accounts[0]}
+        )
         fee_distributor.checkpoint_total_supply()
         fee_distributor.checkpoint_token()
-        epoch=veOCEAN.epoch()
+        epoch = veOCEAN.epoch()
         print(f"\t veOcean epoch: {epoch}")
-        
+
         # fetch user data for all actors
         estimateAlice1w = fromBase18(fee_estimate.estimateClaim(alice))
         estimateBob1w = fromBase18(fee_estimate.estimateClaim(bob))
@@ -84,59 +88,79 @@ def test_rewards():
         epoch_bob = fee_distributor.user_epoch_of(bob)
         time_cursor_alice = fee_distributor.time_cursor_of(alice)
         time_cursor_bob = fee_distributor.time_cursor_of(bob)
-        time_cursor_alice_nice = datetime.utcfromtimestamp(time_cursor_alice).strftime('%Y-%m-%d %H:%M:%S')
-        time_cursor_bob_nice = datetime.utcfromtimestamp(time_cursor_bob).strftime('%Y-%m-%d %H:%M:%S')
-        
-        
-        
-        print(f"\t Alice estimates claim:{estimateAlice1w}, Alice's epoch:{epoch_alice}, Alice's time cursor:{time_cursor_alice} = {time_cursor_alice_nice}")
+        time_cursor_alice_nice = datetime.utcfromtimestamp(time_cursor_alice).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        time_cursor_bob_nice = datetime.utcfromtimestamp(time_cursor_bob).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        print(
+            f"\t Alice estimates claim:{estimateAlice1w}, Alice's epoch:{epoch_alice}, Alice's time cursor:{time_cursor_alice} = {time_cursor_alice_nice}"
+        )
         # Alice claims every week
-        initialAlice=fromBase18(OCEAN.balanceOf(alice))
+        initialAlice = fromBase18(OCEAN.balanceOf(alice))
         fee_distributor.claim({"from": alice})  # alice claims rewards
-        afterAlice=fromBase18(OCEAN.balanceOf(alice))
-        alice_claimed = afterAlice-initialAlice
-        alice_total_withdraws=alice_total_withdraws+alice_claimed
+        afterAlice = fromBase18(OCEAN.balanceOf(alice))
+        alice_claimed = afterAlice - initialAlice
+        alice_total_withdraws = alice_total_withdraws + alice_claimed
         epoch_alice = fee_distributor.user_epoch_of(alice)
         time_cursor_alice = fee_distributor.time_cursor_of(alice)
-        time_cursor_alice_nice = datetime.utcfromtimestamp(time_cursor_alice).strftime('%Y-%m-%d %H:%M:%S')
-        #compare it
-        print(f"\t Alice claimed:{alice_claimed}, After claim:  Alice's epoch:{epoch_alice}, Alice's time cursor:{time_cursor_alice} = {time_cursor_alice_nice}")
-        assert alice_claimed == pytest.approx(estimateAlice1w,0.0000001)
+        time_cursor_alice_nice = datetime.utcfromtimestamp(time_cursor_alice).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        # compare it
+        print(
+            f"\t Alice claimed:{alice_claimed}, After claim:  Alice's epoch:{epoch_alice}, Alice's time cursor:{time_cursor_alice} = {time_cursor_alice_nice}"
+        )
+        assert alice_claimed == pytest.approx(estimateAlice1w, 0.0000001)
 
         # Bob claims every 2 weeks
-        print(f"\t Bob estimates claim:{estimateBob1w}, Bob's epoch:{epoch_bob}, Bob's time cursor:{time_cursor_bob} = {time_cursor_bob_nice}")
-        if i%2==0:
-            initialBob=fromBase18(OCEAN.balanceOf(bob))
+        print(
+            f"\t Bob estimates claim:{estimateBob1w}, Bob's epoch:{epoch_bob}, Bob's time cursor:{time_cursor_bob} = {time_cursor_bob_nice}"
+        )
+        if i % 2 == 0:
+            initialBob = fromBase18(OCEAN.balanceOf(bob))
             fee_distributor.claim({"from": bob})  # bob claims rewards
-            afterBob=fromBase18(OCEAN.balanceOf(bob))
-            bob_claimed = afterBob-initialBob
-            bob_total_withdraws=bob_total_withdraws+bob_claimed
+            afterBob = fromBase18(OCEAN.balanceOf(bob))
+            bob_claimed = afterBob - initialBob
+            bob_total_withdraws = bob_total_withdraws + bob_claimed
             epoch_bob = fee_distributor.user_epoch_of(bob)
             time_cursor_bob = fee_distributor.time_cursor_of(bob)
-            time_cursor_bob_nice = datetime.utcfromtimestamp(time_cursor_bob).strftime('%Y-%m-%d %H:%M:%S')
-            #compare it
-            print(f"\t Bob claimed:{bob_claimed}, after claim Bob's epoch:{epoch_bob}, Bob's time cursor:{time_cursor_bob} = {time_cursor_bob_nice}")
-            assert bob_claimed == pytest.approx(estimateBob1w,0.0000001)
+            time_cursor_bob_nice = datetime.utcfromtimestamp(time_cursor_bob).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            # compare it
+            print(
+                f"\t Bob claimed:{bob_claimed}, after claim Bob's epoch:{epoch_bob}, Bob's time cursor:{time_cursor_bob} = {time_cursor_bob_nice}"
+            )
+            assert bob_claimed == pytest.approx(estimateBob1w, 0.0000001)
 
         # Every 4 weeks, Bob is increasing his lock time, by adding one WEEk (+2 seconds)
-        if i%4==0:
-            bob_lock_time=veOCEAN.locked__end(bob)
-            veOCEAN.increase_unlock_time(bob_lock_time+WEEK+2, { "from": bob})
+        if i % 4 == 0:
+            bob_lock_time = veOCEAN.locked__end(bob)
+            veOCEAN.increase_unlock_time(bob_lock_time + WEEK + 2, {"from": bob})
             print(f"\t Bob increases the lock time")
-            assert bob_claimed == pytest.approx(estimateBob1w,0.0000001)
+            assert bob_claimed == pytest.approx(estimateBob1w, 0.0000001)
 
-        fee_distributor_ocean_balance=fromBase18(OCEAN.balanceOf(fee_distributor.address))
-        fee_distributor_token_last_balance=fromBase18(fee_distributor.token_last_balance())
+        fee_distributor_ocean_balance = fromBase18(
+            OCEAN.balanceOf(fee_distributor.address)
+        )
+        fee_distributor_token_last_balance = fromBase18(
+            fee_distributor.token_last_balance()
+        )
         print(f"\n\t fee_distributor_ocean_balance:{fee_distributor_ocean_balance}")
-        print(f"\t fee_distributor_token_last_balance:{fee_distributor_token_last_balance}")
-        assert fee_distributor_ocean_balance == pytest.approx(fee_distributor_token_last_balance,0.0000001)
+        print(
+            f"\t fee_distributor_token_last_balance:{fee_distributor_token_last_balance}"
+        )
+        assert fee_distributor_ocean_balance == pytest.approx(
+            fee_distributor_token_last_balance, 0.0000001
+        )
 
         print("end week********\n")
 
-    #uncomment the line below to see all debug logs
-    #assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
-
-    
+    # uncomment the line below to see all debug logs
+    # assert fee_distributor.token_last_balance() == 2 #this fails, to see the print statements :)
 
 
 @enforce_types


### PR DESCRIPTION
Iterate over 52 weeks, for multiple actors and cases, to make sure that estimateClaim is accurate