### PR TITLE
Deprecate rinkeby tests

### DIFF
--- a/util/test/test_goerli.py
+++ b/util/test/test_goerli.py
@@ -43,7 +43,6 @@ def test_main(tmp_path):
     with open(fn, "r") as f:
         s = f.read()
 
-    print("s:", s)
     assert " WETH" in s, cmd
 
 


### PR DESCRIPTION
Fixes #332

Changes proposed in this PR:

- Use goerli instead of rinkeby