### PR TITLE
Towards #347 - Refactor calcrewards, for simplicity

### DIFF
--- a/dftool
+++ b/dftool
@@ -257,7 +257,7 @@ SECRET_SEED -- secret integer used to seed the rng
     networkutil.connect(CHAINID)
     chain = brownie.network.chain
     rng = blockrange.create_range(chain, ST, FIN, NSAMP, SECRET_SEED)
-    balances = query.getveBalances(rng, CHAINID)
+    balances = query.queryVebals(rng, CHAINID)
     csvs.saveVebalsCsv(balances, CSV_DIR)
 
     print("dftool vebals: Done")

--- a/dftool
+++ b/dftool
@@ -335,9 +335,7 @@ Usage: dftool calc CSV_DIR TOT_OCEAN [IGNORED]
     _exitIfFileExists(csvs.rewardsinfoCsvFilename(CSV_DIR, "OCEAN"))
 
     # main work
-    allocs = csvs.loadAllocationCsvs(CSV_DIR)
-    vebals = csvs.loadVebalsCsv(CSV_DIR)
-    stakes = allocations.allocsToStakes(allocs, vebals)
+    stakes = allocations.loadStakes(CSV_DIR)
 
     nftvols = csvs.loadNftvolsCsvs(CSV_DIR)
     SYM = csvs.loadSymbolsCsvs(CSV_DIR)

--- a/dftool
+++ b/dftool
@@ -213,7 +213,7 @@ SECRET_SEED -- secret integer used to seed the rng
 
     rng = blockrange.create_range(chain, ST, FIN, NSAMP, SECRET_SEED)
 
-    allocs = query.getAllocations(rng, CHAINID)
+    allocs = query.queryAllocations(rng, CHAINID)
     csvs.saveAllocationCsv(allocs, CSV_DIR)
 
     print("dftool allocations: Done")

--- a/dftool
+++ b/dftool
@@ -167,7 +167,7 @@ Usage: dftool nftinfo CSV_DIR CHAINID
     # create dir if not exists
     _createDirIfNeeded(CSV_DIR)
 
-    nftinfo = query.getNFTInfos(CHAINID)
+    nftinfo = query.queryNftinfo(CHAINID)
     csvs.saveNftinfoCsv(nftinfo, CSV_DIR, CHAINID)
 
     print("dftool nftinfo: Done")
@@ -257,7 +257,7 @@ SECRET_SEED -- secret integer used to seed the rng
     networkutil.connect(CHAINID)
     chain = brownie.network.chain
     rng = blockrange.create_range(chain, ST, FIN, NSAMP, SECRET_SEED)
-    balances = query.queryVebals(rng, CHAINID)
+    balances = query.queryVebalances(rng, CHAINID)
     csvs.saveVebalsCsv(balances, CSV_DIR)
 
     print("dftool vebals: Done")

--- a/dftool
+++ b/dftool
@@ -89,7 +89,7 @@ def do_help():
 # ========================================================================
 @enforce_types
 def do_query():
-    HELP = f"""Query chain, output nft volume csv
+    HELP = f"""Query chain, output nftvols & symbols
 
 Usage: dftool query ST FIN NSAMP CSV_DIR CHAINID
   ST -- first block # to calc on | YYYY-MM-DD | YYYY-MM-DD_HH:MM
@@ -138,7 +138,7 @@ SECRET_SEED -- secret integer used to seed the rng
 
     recordDeployedContracts(ADDRESS_FILE)
     # main work
-    (Vi, SYMi) = query.query_all(rng, CHAINID)
+    (Vi, SYMi) = query.queryNftvolsAndSymbols(rng, CHAINID)
     csvs.saveNftvolsCsv(Vi, CSV_DIR, CHAINID)
     csvs.saveSymbolsCsv(SYMi, CSV_DIR, CHAINID)
 

--- a/util/allocations.py
+++ b/util/allocations.py
@@ -1,6 +1,6 @@
 from enforce_typing import enforce_types
 
-from util import cleancase
+from util import cleancase, csvs
 
 
 @enforce_types
@@ -29,4 +29,17 @@ def allocsToStakes(allocs: dict, vebals: dict) -> dict:
                 stakes[chainID][nft_addr][LP_addr] = stake
 
     cleancase.assertStakes(stakes)
+    return stakes
+
+
+def loadStakes(csv_dir: str) -> dict:
+    """
+    Loads allocs and vebals, computes stakes from it, and returns stakes.
+
+    @return
+      stakes - dict of [chainID][nft_addr][LP_addr] : veOCEAN_float - abs alloc
+    """
+    allocs = csvs.loadAllocationCsvs(csv_dir)
+    vebals = csvs.loadVebalsCsv(csv_dir)
+    stakes = allocsToStakes(allocs, vebals)
     return stakes

--- a/util/csvs.py
+++ b/util/csvs.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Dict, List
 from enforce_typing import enforce_types
 
+from util.allocations import allocsToStakes
 from util.query import DataNFT
 
 
@@ -13,20 +14,19 @@ from util.query import DataNFT
 
 
 @enforce_types
-def saveAllocationCsv(allocations: dict, csv_dir: str):
+def saveAllocationCsv(allocs: dict, csv_dir: str):
     """
     @description
-      Save the allocations csv for this chain. This csv is a key input for
-      dftool calcrewards, and contains just enough info for it to operate, and no more.
+      Save the allocations csv for this chain.
 
     @arguments
-      allocations -- dict of [chain_id][nft_addr][LP_addr] : percent
+      allocs -- dict of [chain_id][nft_addr][LP_addr] : percent_float
       csv_dir -- directory that holds csv files
     """
     assert os.path.exists(csv_dir), csv_dir
     csv_file = allocationCsvFilename(csv_dir)
     assert not os.path.exists(csv_file), csv_file
-    S = allocations
+    S = allocs
     with open(csv_file, "w") as f:
         writer = csv.writer(f)
         row = ["chainID", "nft_addr", "LP_addr", "percent"]
@@ -53,10 +53,10 @@ def loadAllocationCsvs(csv_dir: str) -> Dict[int, Dict[str, Dict[str, float]]]:
       Load allocation csv; return result as a single dict
 
     @return
-      allocation -- dict of [chainID][basetoken_addr][nft_addr][LP_addr] : stake_amt
+      allocs -- dict of [chainID][basetoken_addr][nft_addr][LP_addr] : perc_flt
     """
     csv_file = allocationCsvFilename(csv_dir)
-    V: Dict[int, Dict[str, Dict[str, float]]] = {}
+    allocs: Dict[int, Dict[str, Dict[str, float]]] = {}
     with open(csv_file, "r") as f:
         reader = csv.reader(f)
         for row_i, row in enumerate(reader):
@@ -73,16 +73,16 @@ def loadAllocationCsvs(csv_dir: str) -> Dict[int, Dict[str, Dict[str, float]]]:
             assertIsEthAddr(nft_addr)
             assertIsEthAddr(LP_addr)
 
-            if chainID not in V:
-                V[chainID] = {}
+            if chainID not in allocs:
+                allocs[chainID] = {}
 
-            if nft_addr not in V[chainID]:
-                V[chainID][nft_addr] = {}
+            if nft_addr not in allocs[chainID]:
+                allocs[chainID][nft_addr] = {}
 
-            V[chainID][nft_addr][LP_addr] = percent
+            allocs[chainID][nft_addr][LP_addr] = percent
     print(f"Loaded {csv_file}")
 
-    return V
+    return allocs
 
 
 @enforce_types
@@ -106,14 +106,13 @@ def saveVebalsCsv(vebals: dict, csv_dir: str):
     assert os.path.exists(csv_dir), csv_dir
     csv_file = vebalsCsvFilename(csv_dir)
     assert not os.path.exists(csv_file), csv_file
-    S = vebals
     with open(csv_file, "w") as f:
         writer = csv.writer(f)
         row = ["LP_addr", "balance"]
         writer.writerow(row)
-        for LP_addr in S.keys():
+        for LP_addr in vebals.keys():
             assertIsEthAddr(LP_addr)
-            row = [LP_addr.lower(), S[LP_addr]]
+            row = [LP_addr.lower(), vebals[LP_addr]]
             writer.writerow(row)
 
     print(f"Created {csv_file}")

--- a/util/csvs.py
+++ b/util/csvs.py
@@ -5,7 +5,6 @@ import re
 from typing import Any, Dict, List
 from enforce_typing import enforce_types
 
-from util.allocations import allocsToStakes
 from util.query import DataNFT
 
 

--- a/util/query.py
+++ b/util/query.py
@@ -174,7 +174,7 @@ def queryVebals(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
 
 
 @enforce_types
-def getAllocations(
+def queryAllocations(
     rng: BlockRange, CHAINID: int
 ) -> Dict[int, Dict[str, Dict[str, float]]]:
     """

--- a/util/query.py
+++ b/util/query.py
@@ -66,7 +66,7 @@ def queryNftvolsAndSymbols(
 
 
 @enforce_types
-def getveBalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
+def queryVebals(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
     """
     @description
       Return all ve balances
@@ -83,7 +83,7 @@ def getveBalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
     n_blocks = rng.numBlocks()
     n_blocks_sampled = 0
     blocks = rng.getBlocks()
-    print("getveBalances: begin")
+    print("queryVebals: begin")
 
     for block_i, block in enumerate(blocks):
         if (block_i % 50) == 0 or (block_i == n_blocks - 1):
@@ -168,7 +168,7 @@ def getveBalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
     for user in veBalances:
         veBalances[user] /= n_blocks_sampled
 
-    print("getveBalances: done")
+    print("queryVebals: done")
 
     return veBalances
 

--- a/util/query.py
+++ b/util/query.py
@@ -344,7 +344,7 @@ def queryNftvolsAndSymbols(
       A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
       Basetoken symbols are full uppercase, addresses are full lowercase.
     """
-    Vi_unfiltered = queryNftvolumes(rng.st, rng.fin, chainID)
+    Vi_unfiltered = _queryNftvolumes(rng.st, rng.fin, chainID)
     Vi = _filterNftvols(Vi_unfiltered, chainID)
 
     # get all basetokens from Vi
@@ -356,7 +356,7 @@ def queryNftvolsAndSymbols(
     return (Vi, SYMi)
 
 
-def queryNftvolumes(
+def _queryNftvolumes(
     st_block: int, end_block: int, chainID: int
 ) -> Dict[str, Dict[str, float]]:
     """

--- a/util/query.py
+++ b/util/query.py
@@ -305,7 +305,7 @@ def _populateNftAssetNames(nftInfo: List[DataNFT]) -> List[DataNFT]:
     """
 
     nft_dids = [nft.did for nft in nftInfo]
-    did_to_name = aquarius_asset_names(nft_dids)
+    did_to_name = queryAquariusAssetNames(nft_dids)
 
     for nft in nftInfo:
         nft.setName(did_to_name[nft.did])
@@ -544,7 +544,7 @@ def _filterToAquariusAssets(nft_dids: List[str]) -> List[str]:
     """
     filtered_nft_dids = []
 
-    assets = aquarius_asset_names(nft_dids)
+    assets = queryAquariusAssetNames(nft_dids)
 
     # Aquarius returns "" as the name for assets that isn't in the marketplace
     for did in assets:
@@ -599,7 +599,7 @@ def symbol(addr: str):
 
 
 @enforce_types
-def aquarius_asset_names(
+def queryAquariusAssetNames(
     nft_dids: List[str],
 ) -> Dict[str, str]:
     """

--- a/util/query.py
+++ b/util/query.py
@@ -53,7 +53,7 @@ def queryNftvolsAndSymbols(
       A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
       Basetoken symbols are full uppercase, addresses are full lowercase.
     """
-    Vi_unfiltered = getNFTVolumes(rng.st, rng.fin, chainID)
+    Vi_unfiltered = queryNftvolumes(rng.st, rng.fin, chainID)
     Vi = _filterNftvols(Vi_unfiltered, chainID)
 
     # get all basetokens from Vi
@@ -356,7 +356,7 @@ def _queryNftinfo(chainID) -> List[DataNFT]:
     return nftinfo
 
 
-def getNFTVolumes(
+def queryNftvolumes(
     st_block: int, end_block: int, chainID: int
 ) -> Dict[str, Dict[str, float]]:
     """

--- a/util/query.py
+++ b/util/query.py
@@ -38,34 +38,6 @@ class DataNFT:
 
 
 @enforce_types
-def queryNftvolsAndSymbols(
-    rng: BlockRange, chainID: int
-) -> Tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
-    """
-    @description
-      Return nftvols for the input block range and chain.
-
-    @return
-      nftvols_at_chain -- dict of [basetoken_addr][nft_addr] : vol
-      symbols_at_chain -- dict of [basetoken_addr] : basetoken_symbol
-
-    @notes
-      A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
-      Basetoken symbols are full uppercase, addresses are full lowercase.
-    """
-    Vi_unfiltered = queryNftvolumes(rng.st, rng.fin, chainID)
-    Vi = _filterNftvols(Vi_unfiltered, chainID)
-
-    # get all basetokens from Vi
-    basetokens = TokSet()
-    for basetoken in Vi:
-        _symbol = symbol(basetoken)
-        basetokens.add(chainID, basetoken, _symbol)
-    SYMi = getSymbols(basetokens, chainID)
-    return (Vi, SYMi)
-
-
-@enforce_types
 def queryVebalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
     """
     @description
@@ -354,6 +326,34 @@ def _queryNftinfo(chainID) -> List[DataNFT]:
         offset += chunk_size
 
     return nftinfo
+
+
+@enforce_types
+def queryNftvolsAndSymbols(
+    rng: BlockRange, chainID: int
+) -> Tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
+    """
+    @description
+      Return nftvols for the input block range and chain.
+
+    @return
+      nftvols_at_chain -- dict of [basetoken_addr][nft_addr] : vol
+      symbols_at_chain -- dict of [basetoken_addr] : basetoken_symbol
+
+    @notes
+      A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
+      Basetoken symbols are full uppercase, addresses are full lowercase.
+    """
+    Vi_unfiltered = queryNftvolumes(rng.st, rng.fin, chainID)
+    Vi = _filterNftvols(Vi_unfiltered, chainID)
+
+    # get all basetokens from Vi
+    basetokens = TokSet()
+    for basetoken in Vi:
+        _symbol = symbol(basetoken)
+        basetokens.add(chainID, basetoken, _symbol)
+    SYMi = getSymbols(basetokens, chainID)
+    return (Vi, SYMi)
 
 
 def queryNftvolumes(

--- a/util/query.py
+++ b/util/query.py
@@ -285,14 +285,14 @@ def queryNftinfo(chainID) -> List[DataNFT]:
       nftInfo -- list of DataNFT objects
     """
 
-    NFTinfo = _queryNftinfo(chainID)
+    nftinfo = _queryNftinfo(chainID)
 
     if chainID != networkutil.DEV_CHAINID:
         # filter if not on dev chain
-        NFTinfo = _filterNftinfos(NFTinfo)
-        NFTinfo = _populateNftAssetNames(NFTinfo)
+        nftinfo = _filterNftinfos(nftinfo)
+        nftinfo = _populateNftAssetNames(nftinfo)
 
-    return NFTinfo
+    return nftinfo
 
 
 def _populateNftAssetNames(nftInfo: List[DataNFT]) -> List[DataNFT]:
@@ -321,7 +321,7 @@ def _queryNftinfo(chainID) -> List[DataNFT]:
     @return
       nftInfo -- list of DataNFT objects
     """
-    NFTinfo = []
+    nftinfo = []
     chunk_size = 1000
     offset = 0
 
@@ -349,11 +349,11 @@ def _queryNftinfo(chainID) -> List[DataNFT]:
                 chainID,
                 nft["symbol"],
             )
-            NFTinfo.append(datanft)
+            nftinfo.append(datanft)
 
         offset += chunk_size
 
-    return NFTinfo
+    return nftinfo
 
 
 def getNFTVolumes(

--- a/util/query.py
+++ b/util/query.py
@@ -63,7 +63,7 @@ def queryNftvolsAndSymbols(
         basetokens.add(chainID, basetoken, _symbol)
     SYMi = getSymbols(basetokens, chainID)
     return (Vi, SYMi)
-    
+
 
 @enforce_types
 def queryVebalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:

--- a/util/query.py
+++ b/util/query.py
@@ -38,7 +38,7 @@ class DataNFT:
 
 
 @enforce_types
-def query_all(
+def queryNftvolsAndSymbols(
     rng: BlockRange, chainID: int
 ) -> Tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
     """

--- a/util/query.py
+++ b/util/query.py
@@ -38,6 +38,34 @@ class DataNFT:
 
 
 @enforce_types
+def queryNftvolsAndSymbols(
+    rng: BlockRange, chainID: int
+) -> Tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
+    """
+    @description
+      Return nftvols for the input block range and chain.
+
+    @return
+      nftvols_at_chain -- dict of [basetoken_addr][nft_addr] : vol
+      symbols_at_chain -- dict of [basetoken_addr] : basetoken_symbol
+
+    @notes
+      A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
+      Basetoken symbols are full uppercase, addresses are full lowercase.
+    """
+    Vi_unfiltered = _queryNftvolumes(rng.st, rng.fin, chainID)
+    Vi = _filterNftvols(Vi_unfiltered, chainID)
+
+    # get all basetokens from Vi
+    basetokens = TokSet()
+    for basetoken in Vi:
+        _symbol = symbol(basetoken)
+        basetokens.add(chainID, basetoken, _symbol)
+    SYMi = getSymbols(basetokens, chainID)
+    return (Vi, SYMi)
+    
+
+@enforce_types
 def queryVebalances(rng: BlockRange, CHAINID: int) -> Dict[str, float]:
     """
     @description
@@ -326,34 +354,6 @@ def _queryNftinfo(chainID) -> List[DataNFT]:
         offset += chunk_size
 
     return nftinfo
-
-
-@enforce_types
-def queryNftvolsAndSymbols(
-    rng: BlockRange, chainID: int
-) -> Tuple[Dict[str, Dict[str, float]], Dict[str, str]]:
-    """
-    @description
-      Return nftvols for the input block range and chain.
-
-    @return
-      nftvols_at_chain -- dict of [basetoken_addr][nft_addr] : vol
-      symbols_at_chain -- dict of [basetoken_addr] : basetoken_symbol
-
-    @notes
-      A stake or nftvol value is in terms of basetoken (eg OCEAN, H2O).
-      Basetoken symbols are full uppercase, addresses are full lowercase.
-    """
-    Vi_unfiltered = _queryNftvolumes(rng.st, rng.fin, chainID)
-    Vi = _filterNftvols(Vi_unfiltered, chainID)
-
-    # get all basetokens from Vi
-    basetokens = TokSet()
-    for basetoken in Vi:
-        _symbol = symbol(basetoken)
-        basetokens.add(chainID, basetoken, _symbol)
-    SYMi = getSymbols(basetokens, chainID)
-    return (Vi, SYMi)
 
 
 def _queryNftvolumes(

--- a/util/test/test_allocations.py
+++ b/util/test/test_allocations.py
@@ -21,23 +21,23 @@ def test_empty():
 def test_lp1_one_allocation():
     perc_allocs = {C1: {NA: {ST1: 1.0}}}
     vebals = {ST1: 10.0}
-    abs_allocs = allocsToStakes(perc_allocs, vebals)
-    assert abs_allocs == {C1: {NA: {ST1: 10.0}}}
+    stakes = allocsToStakes(perc_allocs, vebals)
+    assert stakes == {C1: {NA: {ST1: 10.0}}}
 
 
 @enforce_types
 def test_lp1_two_allocations():
     perc_allocs = {C1: {NA: {ST1: 0.1}, NB: {ST1: 0.9}}}
     vebals = {ST1: 10.0}
-    abs_allocs = allocsToStakes(perc_allocs, vebals)
-    assert abs_allocs == {C1: {NA: {ST1: 1.0}, NB: {ST1: 9.0}}}
+    stakes = allocsToStakes(perc_allocs, vebals)
+    assert stakes == {C1: {NA: {ST1: 1.0}, NB: {ST1: 9.0}}}
 
 
 @enforce_types
 def test_lp1_two_allocations__lp2_two_allocations():
     perc_allocs = {C1: {NA: {ST1: 0.1, ST2: 0.2}, NB: {ST1: 0.9, ST2: 0.8}}}
     vebals = {ST1: 10.0, ST2: 100.0}
-    abs_allocs = allocsToStakes(perc_allocs, vebals)
-    assert abs_allocs == {
+    stakes = allocsToStakes(perc_allocs, vebals)
+    assert stakes == {
         C1: {NA: {ST1: 1.0, ST2: 0.2 * 100}, NB: {ST1: 9.0, ST2: 0.8 * 100}}
     }

--- a/util/test/test_allocations.py
+++ b/util/test/test_allocations.py
@@ -1,6 +1,7 @@
 from enforce_typing import enforce_types
 
-from util.allocations import allocsToStakes
+from util import csvs
+from util.allocations import allocsToStakes, loadStakes
 
 # for shorter lines
 C1, C2 = 7, 137
@@ -41,3 +42,18 @@ def test_lp1_two_allocations__lp2_two_allocations():
     assert stakes == {
         C1: {NA: {ST1: 1.0, ST2: 0.2 * 100}, NB: {ST1: 9.0, ST2: 0.8 * 100}}
     }
+
+
+@enforce_types
+def test_load_stakes(tmp_path):
+    csv_dir = str(tmp_path)
+
+    allocs = {C1: {NA: {ST1: 0.1, ST2: 1.0}, NB: {ST1: 0.2}}}
+    csvs.saveAllocationCsv(allocs, csv_dir)
+
+    vebals = {ST1: 100.0, ST2: 200.0}
+    csvs.saveVebalsCsv(vebals, csv_dir)
+
+    target_stakes = allocsToStakes(allocs, vebals)
+    loaded_stakes = loadStakes(csv_dir)
+    assert loaded_stakes == target_stakes

--- a/util/test/test_csvs.py
+++ b/util/test/test_csvs.py
@@ -56,11 +56,11 @@ def test_allocations_twochains(tmp_path):
     }
     S2 = {PD: {LP1: 4.1, LP5: 4.5}, PE: {LP6: 5.6}}
 
-    allcs = {1: S1, 2: S2}
+    allocs = {1: S1, 2: S2}
 
-    csvs.saveAllocationCsv(allcs, csv_dir)
-    allcs_loaded = csvs.loadAllocationCsvs(csv_dir)
-    assert allcs_loaded == allcs
+    csvs.saveAllocationCsv(allocs, csv_dir)
+    allocs_loaded = csvs.loadAllocationCsvs(csv_dir)
+    assert allocs_loaded == allocs
 
 
 # =================================================================

--- a/util/test/test_csvs.py
+++ b/util/test/test_csvs.py
@@ -6,7 +6,7 @@ from util import csvs
 
 # for shorter lines
 C1, C2 = 1, 137
-PA, PB, PC, PD, PE, PF = "0xpa", "0xpb", "0xpc", "0xpd", "0xpe", "0xpf"  # pools
+PA, PB, PC, PD, PE, PF = "0xpa", "0xpb", "0xpc", "0xpd", "0xpe", "0xpf"  # nfts
 LP1, LP2, LP3, LP4, LP5, LP6 = "0xlp1", "0xlp2", "0xlp3", "0xlp4", "0xlp5", "0xlp6"
 OCN_SYMB, H2O_SYMB = "OCN", "H2O"
 OCN_ADDR, H2O_ADDR = "0xocn_addr", "0xh2o_addr"  # all lowercase
@@ -20,43 +20,51 @@ OCN_ADDR2, H2O_ADDR2 = "0xOCN_AdDr", "0xh2O_ADDR"  # not all lowercase
 @enforce_types
 def test_allocations_onechain_lowercase(tmp_path):
     csv_dir = str(tmp_path)
-    S1 = {PA: {LP1: 1.1, LP2: 1.2}, PB: {LP1: 2.1, LP3: 2.3}, PC: {LP1: 3.1, LP4: 3.4}}
-    A1 = {1: S1}
-    csvs.saveAllocationCsv(A1, csv_dir)
-    A1_loaded = csvs.loadAllocationCsvs(csv_dir)
-    assert A1_loaded == A1
+    allocs = {
+        C1: {
+            PA: {LP1: 0.1, LP2: 1.0},
+            PB: {LP1: 0.2, LP3: 1.0},
+            PC: {LP1: 0.7, LP4: 1.0},
+        }
+    }
+    csvs.saveAllocationCsv(allocs, csv_dir)
+    allocs_loaded = csvs.loadAllocationCsvs(csv_dir)
+    assert allocs_loaded == allocs
 
 
 @enforce_types
 def test_allocations_onechain_mixedcase(tmp_path):
     csv_dir = str(tmp_path)
-    S1_lowercase = {
-        PA: {LP1: 1.1, LP2: 1.2},
-        PB: {LP1: 2.1, LP3: 2.3},
-        PC: {LP1: 3.1, LP4: 3.4},
+    allocs_lowercase = {
+        C1: {
+            PA: {"0xlp1": 0.1, "0xlp2": 1.0},
+            PB: {"0xlp1": 0.2, "0xlp3": 1.0},
+            PC: {"0xlp1": 0.7, "0xlp4": 1.0},
+        }
     }
-    S1_mixedcase = {
-        PA: {LP1: 1.1, LP2: 1.2},
-        PB: {LP1: 2.1, LP3: 2.3},
-        PC: {LP1: 3.1, LP4: 3.4},
+    allocs_mixedcase = {
+        C1: {
+            PA: {"0xlP1": 0.1, "0xLP2": 1.0},
+            PB: {"0xLp1": 0.2, "0xlp3": 1.0},
+            PC: {"0xlp1": 0.7, "0xLp4": 1.0},
+        }
     }
-    A1 = {1: S1_mixedcase}
-    csvs.saveAllocationCsv(A1, csv_dir)
-    S1_loaded = csvs.loadAllocationCsvs(csv_dir)
-    assert S1_loaded[1] == S1_lowercase
+    csvs.saveAllocationCsv(allocs_mixedcase, csv_dir)
+    allocs_loaded = csvs.loadAllocationCsvs(csv_dir)
+    assert allocs_loaded == allocs_lowercase
 
 
 @enforce_types
 def test_allocations_twochains(tmp_path):
     csv_dir = str(tmp_path)
-    S1 = {
-        PA: {LP1: 1.1, LP2: 1.2},
-        PB: {LP1: 2.1, LP3: 2.3},
-        PC: {LP1: 3.1, LP4: 3.4},
+    allocs = {
+        C1: {
+            PA: {LP1: 0.1, LP2: 1.0},
+            PB: {LP1: 0.3, LP3: 1.0},
+            PC: {LP1: 0.5, LP4: 1.0},
+        },
+        C2: {PD: {LP1: 0.1, LP5: 1.0}, PE: {LP6: 1.0}},
     }
-    S2 = {PD: {LP1: 4.1, LP5: 4.5}, PE: {LP6: 5.6}}
-
-    allocs = {1: S1, 2: S2}
 
     csvs.saveAllocationCsv(allocs, csv_dir)
     allocs_loaded = csvs.loadAllocationCsvs(csv_dir)
@@ -69,11 +77,10 @@ def test_allocations_twochains(tmp_path):
 
 @enforce_types
 def test_vebals(tmp_path):
-    vebals = {LP1: 1.0, LP2: 2.0, LP3: 3.0}
-
     csv_dir = str(tmp_path)
-    csvs.saveVebalsCsv(vebals, csv_dir)
 
+    vebals = {LP1: 1.0, LP2: 2.0, LP3: 3.0}
+    csvs.saveVebalsCsv(vebals, csv_dir)
     loaded_vebals = csvs.loadVebalsCsv(csv_dir)
     assert loaded_vebals == vebals
 

--- a/util/test/test_csvs.py
+++ b/util/test/test_csvs.py
@@ -64,6 +64,21 @@ def test_allocations_twochains(tmp_path):
 
 
 # =================================================================
+# vebals csvs
+
+
+@enforce_types
+def test_vebals(tmp_path):
+    vebals = {LP1: 1.0, LP2: 2.0, LP3: 3.0}
+
+    csv_dir = str(tmp_path)
+    csvs.saveVebalsCsv(vebals, csv_dir)
+
+    loaded_vebals = csvs.loadVebalsCsv(csv_dir)
+    assert loaded_vebals == vebals
+
+
+# =================================================================
 # nftvols csvs
 
 

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -28,7 +28,7 @@ def test_without_csvs():
     st, fin, n = ST, FIN, 25
     rng = blockrange.BlockRange(st, fin, n)
 
-    (V0, SYM0) = query.query_all(rng, chainID)
+    (V0, SYM0) = query.queryNftvolsAndSymbols(rng, chainID)
 
     vebals = query.getveBalances(rng, chainID)
     allocs = query.getAllocations(rng, chainID)
@@ -70,7 +70,7 @@ def test_with_csvs(tmp_path):
     csvs.saveRateCsv("H2O", 1.61, csv_dir)
 
     # 2. simulate "dftool query"
-    (V0, SYM0) = query.query_all(rng, chainID)
+    (V0, SYM0) = query.queryNftvolsAndSymbols(rng, chainID)
     csvs.saveNftvolsCsv(V0, csv_dir, chainID)
     csvs.saveSymbolsCsv(SYM0, csv_dir, chainID)
     V0 = SYM0 = None  # ensure not used later

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -30,7 +30,7 @@ def test_without_csvs():
 
     (V0, SYM0) = query.queryNftvolsAndSymbols(rng, chainID)
 
-    vebals = query.queryVebals(rng, chainID)
+    vebals = query.queryVebalances(rng, chainID)
     allocs = query.queryAllocations(rng, chainID)
     stakes = allocations.allocsToStakes(allocs, vebals)
 
@@ -75,7 +75,7 @@ def test_with_csvs(tmp_path):
     csvs.saveSymbolsCsv(SYM0, csv_dir, chainID)
     V0 = SYM0 = None  # ensure not used later
 
-    vebals = query.queryVebals(rng, chainID)
+    vebals = query.queryVebalances(rng, chainID)
     allocs = query.queryAllocations(rng, chainID)
     csvs.saveVebalsCsv(vebals, csv_dir)
     csvs.saveAllocationCsv(allocs, csv_dir)

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -86,9 +86,7 @@ def test_with_csvs(tmp_path):
     V = csvs.loadNftvolsCsvs(csv_dir)
     SYM = csvs.loadSymbolsCsvs(csv_dir)
 
-    allocs = csvs.loadAllocationCsvs(csv_dir)
-    vebals = csvs.loadVebalsCsv(csv_dir)
-    stakes = allocations.allocsToStakes(allocs, vebals)
+    stakes = allocations.loadStakes(csv_dir) # loads allocs & vebals, then *
 
     OCEAN_avail = 0.0001
     rewardsperlp, _ = calcrewards.calcRewards(stakes, V, SYM, R, OCEAN_avail)

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -30,7 +30,7 @@ def test_without_csvs():
 
     (V0, SYM0) = query.queryNftvolsAndSymbols(rng, chainID)
 
-    vebals = query.getveBalances(rng, chainID)
+    vebals = query.queryVebals(rng, chainID)
     allocs = query.getAllocations(rng, chainID)
     stakes = allocations.allocsToStakes(allocs, vebals)
 
@@ -75,7 +75,7 @@ def test_with_csvs(tmp_path):
     csvs.saveSymbolsCsv(SYM0, csv_dir, chainID)
     V0 = SYM0 = None  # ensure not used later
 
-    vebals = query.getveBalances(rng, chainID)
+    vebals = query.queryVebals(rng, chainID)
     allocs = query.getAllocations(rng, chainID)
     csvs.saveVebalsCsv(vebals, csv_dir)
     csvs.saveAllocationCsv(allocs, csv_dir)

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -86,7 +86,7 @@ def test_with_csvs(tmp_path):
     V = csvs.loadNftvolsCsvs(csv_dir)
     SYM = csvs.loadSymbolsCsvs(csv_dir)
 
-    stakes = allocations.loadStakes(csv_dir) # loads allocs & vebals, then *
+    stakes = allocations.loadStakes(csv_dir)  # loads allocs & vebals, then *
 
     OCEAN_avail = 0.0001
     rewardsperlp, _ = calcrewards.calcRewards(stakes, V, SYM, R, OCEAN_avail)

--- a/util/test/test_end-to-end.py
+++ b/util/test/test_end-to-end.py
@@ -31,7 +31,7 @@ def test_without_csvs():
     (V0, SYM0) = query.queryNftvolsAndSymbols(rng, chainID)
 
     vebals = query.queryVebals(rng, chainID)
-    allocs = query.getAllocations(rng, chainID)
+    allocs = query.queryAllocations(rng, chainID)
     stakes = allocations.allocsToStakes(allocs, vebals)
 
     R = {"OCEAN": 0.5, "H2O": 1.618}
@@ -76,7 +76,7 @@ def test_with_csvs(tmp_path):
     V0 = SYM0 = None  # ensure not used later
 
     vebals = query.queryVebals(rng, chainID)
-    allocs = query.getAllocations(rng, chainID)
+    allocs = query.queryAllocations(rng, chainID)
     csvs.saveVebalsCsv(vebals, csv_dir)
     csvs.saveAllocationCsv(allocs, csv_dir)
     vebals = allocs = None  # ensure not used later

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -112,7 +112,7 @@ def test_all():
     # run actual tests
     _test_getSymbols()
     _test_getNFTVolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
-    _test_queryVebals(blockRange, sampling_accounts_addrs)
+    _test_queryVebalances(blockRange, sampling_accounts_addrs)
     _test_queryAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
     _test_nft_infos()
@@ -130,8 +130,8 @@ def _foundConsume(CO2_ADDR, st, fin):
 
 
 @enforce_types
-def _test_queryVebals(rng: BlockRange, sampling_accounts: list):
-    veBalances = query.queryVebals(rng, CHAINID)
+def _test_queryVebalances(rng: BlockRange, sampling_accounts: list):
+    veBalances = query.queryVebalances(rng, CHAINID)
     assert len(veBalances) > 0
     assert sum(veBalances.values()) > 0
 
@@ -195,7 +195,7 @@ def _test_queryNFtVolsAndSymbols(CO2_ADDR: str):
 
 @enforce_types
 def _test_nft_infos():
-    nfts = query.getNFTInfos(CHAINID)
+    nfts = query.queryNftinfo(CHAINID)
     assert len(nfts) > 0
 
 

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -114,8 +114,8 @@ def test_all():
     _test_queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
     _test_queryVebalances(blockRange, sampling_accounts_addrs)
     _test_queryAllocations(blockRange, sampling_accounts_addrs)
-    _test_query(CO2_ADDR)
-    _test_nft_infos()
+    _test_queryNftvolsAndSymbols(CO2_ADDR)
+    _test_queryNftinfo()
 
 
 def _foundConsume(CO2_ADDR, st, fin):

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -184,7 +184,7 @@ def _test_queryNftvolumes(CO2_ADDR: str, st, fin):
 
 
 @enforce_types
-def _test_queryNFtVolsAndSymbols(CO2_ADDR: str):
+def _test_queryNftvolsAndSymbols(CO2_ADDR: str):
     st, fin, n = QUERY_ST, len(brownie.network.chain), 500
     rng = BlockRange(st, fin, n)
     (V0, SYM0) = query.queryNftvolsAndSymbols(rng, CHAINID)

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -113,7 +113,7 @@ def test_all():
     _test_getSymbols()
     _test_getNFTVolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
     _test_queryVebals(blockRange, sampling_accounts_addrs)
-    _test_getAllocations(blockRange, sampling_accounts_addrs)
+    _test_queryAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
     _test_nft_infos()
 
@@ -144,8 +144,8 @@ def _test_queryVebals(rng: BlockRange, sampling_accounts: list):
 
 
 @enforce_types
-def _test_getAllocations(rng: BlockRange, sampling_accounts: list):
-    allocations = query.getAllocations(rng, CHAINID)
+def _test_queryAllocations(rng: BlockRange, sampling_accounts: list):
+    allocations = query.queryAllocations(rng, CHAINID)
 
     assert len(allocations) > 0
 

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -112,7 +112,7 @@ def test_all():
     # run actual tests
     _test_getSymbols()
     _test_getNFTVolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
-    _test_getveBalances(blockRange, sampling_accounts_addrs)
+    _test_queryVebals(blockRange, sampling_accounts_addrs)
     _test_getAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
     _test_nft_infos()
@@ -130,8 +130,8 @@ def _foundConsume(CO2_ADDR, st, fin):
 
 
 @enforce_types
-def _test_getveBalances(rng: BlockRange, sampling_accounts: list):
-    veBalances = query.getveBalances(rng, CHAINID)
+def _test_queryVebals(rng: BlockRange, sampling_accounts: list):
+    veBalances = query.queryVebals(rng, CHAINID)
     assert len(veBalances) > 0
     assert sum(veBalances.values()) > 0
 

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -184,10 +184,10 @@ def _test_getNFTVolumes(CO2_ADDR: str, st, fin):
 
 
 @enforce_types
-def _test_query(CO2_ADDR: str):
+def _test_queryNFtVolsAndSymbols(CO2_ADDR: str):
     st, fin, n = QUERY_ST, len(brownie.network.chain), 500
     rng = BlockRange(st, fin, n)
-    (V0, SYM0) = query.query_all(rng, CHAINID)
+    (V0, SYM0) = query.queryNftvolsAndSymbols(rng, CHAINID)
 
     assert CO2_ADDR in V0
     assert SYM0

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -214,7 +214,7 @@ def test_symbol():
 
 
 @enforce_types
-def test_aquarius_asset_names():
+def test_queryAquariusAssetNames():
     # test that we can get the asset names from aquarius
     nft_dids = [
         "did:op:6d2e99a4d4d501b6ebc0c60d0d6899305c4e8ecbc7293c132841e8d46832bd89",
@@ -224,7 +224,7 @@ def test_aquarius_asset_names():
         "did:op:4aa86d2c10f9a352ac9ec062122e318d66be6777e9a37c982e46aab144bc1cfa",
     ]
     expectedAssetNames = ["Trent", "c2d fresh dataset", "CryptoPunks dataset C2D", ""]
-    assetNames = query.aquarius_asset_names(nft_dids)
+    assetNames = query.queryAquariusAssetNames(nft_dids)
     assert len(assetNames) == 4
 
     for i in range(4):

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -111,7 +111,7 @@ def test_all():
 
     # run actual tests
     _test_getSymbols()
-    _test__queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
+    _test_queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
     _test_queryVebalances(blockRange, sampling_accounts_addrs)
     _test_queryAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
@@ -177,7 +177,7 @@ def _test_getSymbols():
 
 
 @enforce_types
-def _test__queryNftvolumes(CO2_ADDR: str, st, fin):
+def _test_queryNftvolumes(CO2_ADDR: str, st, fin):
     DT_vols = query._queryNftvolumes(st, fin, CHAINID)
     assert CO2_ADDR in DT_vols, (CO2_ADDR, DT_vols.keys())
     assert sum(DT_vols[CO2_ADDR].values()) > 0.0
@@ -194,7 +194,7 @@ def _test_queryNftvolsAndSymbols(CO2_ADDR: str):
 
 
 @enforce_types
-def _test_nft_infos():
+def _test_queryNftinfo():
     nfts = query.queryNftinfo(CHAINID)
     assert len(nfts) > 0
 

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -111,7 +111,7 @@ def test_all():
 
     # run actual tests
     _test_getSymbols()
-    _test_getNFTVolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
+    _test_queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
     _test_queryVebalances(blockRange, sampling_accounts_addrs)
     _test_queryAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
@@ -119,7 +119,7 @@ def test_all():
 
 
 def _foundConsume(CO2_ADDR, st, fin):
-    DT_vols = query.getNFTVolumes(st, fin, CHAINID)
+    DT_vols = query.queryNftvolumes(st, fin, CHAINID)
     if CO2_ADDR not in DT_vols:
         return False
     if sum(DT_vols[CO2_ADDR].values()) == 0:
@@ -177,8 +177,8 @@ def _test_getSymbols():
 
 
 @enforce_types
-def _test_getNFTVolumes(CO2_ADDR: str, st, fin):
-    DT_vols = query.getNFTVolumes(st, fin, CHAINID)
+def _test_queryNftvolumes(CO2_ADDR: str, st, fin):
+    DT_vols = query.queryNftvolumes(st, fin, CHAINID)
     assert CO2_ADDR in DT_vols, (CO2_ADDR, DT_vols.keys())
     assert sum(DT_vols[CO2_ADDR].values()) > 0.0
 

--- a/util/test/test_query.py
+++ b/util/test/test_query.py
@@ -111,7 +111,7 @@ def test_all():
 
     # run actual tests
     _test_getSymbols()
-    _test_queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
+    _test__queryNftvolumes(CO2_ADDR, startBlockNumber, endBlockNumber)
     _test_queryVebalances(blockRange, sampling_accounts_addrs)
     _test_queryAllocations(blockRange, sampling_accounts_addrs)
     _test_query(CO2_ADDR)
@@ -119,7 +119,7 @@ def test_all():
 
 
 def _foundConsume(CO2_ADDR, st, fin):
-    DT_vols = query.queryNftvolumes(st, fin, CHAINID)
+    DT_vols = query._queryNftvolumes(st, fin, CHAINID)
     if CO2_ADDR not in DT_vols:
         return False
     if sum(DT_vols[CO2_ADDR].values()) == 0:
@@ -177,8 +177,8 @@ def _test_getSymbols():
 
 
 @enforce_types
-def _test_queryNftvolumes(CO2_ADDR: str, st, fin):
-    DT_vols = query.queryNftvolumes(st, fin, CHAINID)
+def _test__queryNftvolumes(CO2_ADDR: str, st, fin):
+    DT_vols = query._queryNftvolumes(st, fin, CHAINID)
     assert CO2_ADDR in DT_vols, (CO2_ADDR, DT_vols.keys())
     assert sum(DT_vols[CO2_ADDR].values()) > 0.0
 


### PR DESCRIPTION
Towards #347 

- add unit tests for csvs vebals
- add allocations.loadStakes(). It loads allocations & vebals, then combines them. Use it.
- rename query.getX() to query.queryX(), for all X, for consistency. 
- make variable names follow camel case, where variable itself is treated as a single word. E.g. getveBalances() -> getVebalances()
- rename query.query_all() to query.queryNftvolsAndSymbols(), to better reflect what it does
