### PR TITLE
use OCEAN locked when constraining to 125% APY instead of veOcean

### DIFF
--- a/util/allocations.py
+++ b/util/allocations.py
@@ -40,6 +40,6 @@ def loadStakes(csv_dir: str) -> dict:
       stakes - dict of [chainID][nft_addr][LP_addr] : veOCEAN_float - abs alloc
     """
     allocs = csvs.loadAllocationCsvs(csv_dir)
-    vebals, _, _ = csvs.loadVebalsCsv(csv_dir)
-    stakes = allocsToStakes(allocs, vebals)
+    _ , locked_amts , _ = csvs.loadVebalsCsv(csv_dir)
+    stakes = allocsToStakes(allocs, locked_amts)
     return stakes


### PR DESCRIPTION
Fixes # 380

Changes proposed in this PR:

- use locked_amounts instead of veBalance

