### PR TITLE
test_dftool.py cleanup

### DIFF
--- a/util/oceantestutil.py
+++ b/util/oceantestutil.py
@@ -4,7 +4,6 @@ import brownie
 from enforce_typing import enforce_types
 from util import constants, oceanutil
 from util.base18 import toBase18, fromBase18
-from util.random_addresses import get_random_addresses
 
 network = brownie.network
 
@@ -32,10 +31,9 @@ MIN_POOL_BPTS_OUT_FROM_STAKE = 0.1
 def fillAccountsWithToken(token):
     accounts = network.accounts
     for i in range(1, 10):
-        bal_before: int = fromBase18(token.balanceOf(accounts[i]))
-        if bal_before < 1000:
+        bal_before = fromBase18(token.balanceOf(accounts[i]))
+        if bal_before < 1000.0:
             token.transfer(accounts[i], toBase18(1000.0), {"from": accounts[0]})
-        # bal_after: int = fromBase18(token.balanceOf(accounts[i]))
 
     print(f"fillAccountsWithToken({token.symbol()}), balances after:")
     for i in range(10):
@@ -174,11 +172,9 @@ def randomLockAndAllocate(tups: list):
 
     acc1 = network.accounts[0]
     OCEAN = oceanutil.OCEANtoken()
+    veOCEAN = oceanutil.veOCEAN()
 
-    accounts = [
-        network.accounts.at(addr, force=True)
-        for addr in get_random_addresses(len(tups))
-    ]
+    accounts = network.accounts[: len(tups)]
     for account in accounts:
         OCEAN.mint(account, LOCK_AMOUNT, {"from": acc1})
 
@@ -198,15 +194,15 @@ def randomLockAndAllocate(tups: list):
 
         # Approve locking OCEAN
         assert OCEAN.balanceOf(lock_account) != 0
-        OCEAN.approve(oceanutil.veOCEAN().address, LOCK_AMOUNT, {"from": lock_account})
+        OCEAN.approve(veOCEAN, LOCK_AMOUNT, {"from": lock_account})
 
         # Check if there is an active lock
-        if oceanutil.veOCEAN().balanceOf(lock_account) == 0:
+        if veOCEAN.balanceOf(lock_account) == 0:
             # Create lock
-            oceanutil.veOCEAN().withdraw({"from": lock_account})
-            oceanutil.veOCEAN().create_lock(LOCK_AMOUNT, t2, {"from": lock_account})
+            veOCEAN.withdraw({"from": lock_account})
+            veOCEAN.create_lock(LOCK_AMOUNT, t2, {"from": lock_account})
 
-        assert oceanutil.veOCEAN().balanceOf(lock_account) != 0
+        assert veOCEAN.balanceOf(lock_account) != 0
         allc_amt = constants.MAX_ALLOCATE - oceanutil.veAllocate().getTotalAllocation(
             lock_account
         )

--- a/util/test/test_dftool1.py
+++ b/util/test/test_dftool1.py
@@ -1,0 +1,128 @@
+# test_dftool1 - doesn't need network / brownie
+# test_dftool2 - needs network/brownie with light setup
+# test_dftool3 - needs network/brownie with heavy setup
+
+import os
+import subprocess
+
+from enforce_typing import enforce_types
+
+from util import csvs, oceanutil, networkutil
+
+CHAINID = networkutil.DEV_CHAINID
+
+@enforce_types
+def test_nftinfo(tmp_path):
+    # insert fake inputs:
+    # <nothing to insert>
+
+    # main cmd
+    FIN = "2022-02-02"
+    CSV_DIR = str(tmp_path)
+
+    cmd = f"./dftool nftinfo {CSV_DIR} {CHAINID} {FIN}"
+    os.system(cmd)
+
+    # test result
+    assert csvs.nftinfoCsvFilename(CSV_DIR, CHAINID)
+
+
+@enforce_types
+def test_getrate(tmp_path):
+    # insert fake inputs:
+    # <nothing to insert>
+
+    # main cmd
+    TOKEN_SYMBOL = "OCEAN"
+    _ST = "2022-01-01"
+    FIN = "2022-02-02"
+    CSV_DIR = str(tmp_path)
+
+    cmd = f"./dftool getrate {TOKEN_SYMBOL} {_ST} {FIN} {CSV_DIR}"
+    os.system(cmd)
+
+    # test result
+    assert csvs.rateCsvFilenames(CSV_DIR)
+
+
+@enforce_types
+def test_calc(tmp_path):
+    CSV_DIR = str(tmp_path)
+    OCEAN_addr = "0x967da4048cd07ab37855c090aaf366e4ce1b9f48"
+
+    # insert fake csvs
+    allocations = {CHAINID: {"0xpool_addra": {"0xlp_addr1": 1.0}}}
+    csvs.saveAllocationCsv(allocations, CSV_DIR)
+
+    nftvolts_at_chain = {OCEAN_addr: {"0xpool_addra": 1.0}}
+    csvs.saveNftvolsCsv(nftvolts_at_chain, CSV_DIR, CHAINID)
+
+    vebals = {"0xlp_addr1": 1.0}
+    locked_amt = {"0xlp_addr1": 10.0}
+    unlock_time = {"0xlp_addr1": 1}
+    csvs.saveVebalsCsv(vebals, locked_amt, unlock_time, CSV_DIR)
+
+    symbols_at_chain = {OCEAN_addr: "OCEAN"}
+    csvs.saveSymbolsCsv(symbols_at_chain, CSV_DIR, CHAINID)
+
+    csvs.saveRateCsv("OCEAN", 0.50, CSV_DIR)
+
+    # main cmd
+    TOT_OCEAN = 1000.0
+    cmd = f"./dftool calc {CSV_DIR} {TOT_OCEAN}"
+    os.system(cmd)
+
+    # test result
+    rewards_csv = csvs.rewardsperlpCsvFilename(CSV_DIR, "OCEAN")
+    assert os.path.exists(rewards_csv)
+
+
+@enforce_types
+def test_manyrandom():
+    cmd = f"./dftool manyrandom {networkutil.DEV_CHAINID}"
+    output_s = ""
+    with subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    ) as proc:
+        while proc.poll() is None:
+            output_s += proc.stdout.readline().decode("ascii")
+    return_code = proc.wait()
+    assert return_code == 0, f"Error. \n{output_s}"
+
+
+@enforce_types
+def test_noarg_commands():
+    # Test commands that have no args. They're usually help commands;
+    # sometimes they do the main work (eg compile).
+    argv1s = [
+        "",
+        "query",
+        "volsym",
+        "getrate",
+        "calc",
+        "dispense",
+        "dispense_active",
+        "querymany",
+        "compile",
+        "manyrandom",
+        "newdfrewards",
+        "mine",
+        "newacct",
+        "newtoken",
+        "acctinfo",
+        "chaininfo",
+    ]
+    for argv1 in argv1s:
+        print(f"Test dftool {argv1}")
+        cmd = f"./dftool {argv1}"
+
+        output_s = ""
+        with subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        ) as proc:
+            while proc.poll() is None:
+                output_s += proc.stdout.readline().decode("ascii")
+
+        return_code = proc.wait()
+        assert return_code == 0, f"'dftool {argv1}' failed. \n{output_s}"
+

--- a/util/test/test_dftool1.py
+++ b/util/test/test_dftool1.py
@@ -7,9 +7,10 @@ import subprocess
 
 from enforce_typing import enforce_types
 
-from util import csvs, oceanutil, networkutil
+from util import csvs, networkutil
 
 CHAINID = networkutil.DEV_CHAINID
+
 
 @enforce_types
 def test_nftinfo(tmp_path):
@@ -125,4 +126,3 @@ def test_noarg_commands():
 
         return_code = proc.wait()
         assert return_code == 0, f"'dftool {argv1}' failed. \n{output_s}"
-

--- a/util/test/test_dftool2.py
+++ b/util/test/test_dftool2.py
@@ -1,3 +1,5 @@
+# test_dftool1 - lightweight, doesn't need network
+# test_dftool2 - uses network / brownie
 import os
 import subprocess
 import time
@@ -38,40 +40,6 @@ def test_query(tmp_path):
     # test result
     assert csvs.nftvolsCsvFilenames(CSV_DIR)
     assert csvs.symbolsCsvFilenames(CSV_DIR)
-
-
-@enforce_types
-def test_nftinfo(tmp_path):
-    # insert fake inputs:
-    # <nothing to insert>
-
-    # main cmd
-    FIN = "2022-02-02"
-    CSV_DIR = str(tmp_path)
-
-    cmd = f"./dftool nftinfo {CSV_DIR} {CHAINID} {FIN}"
-    os.system(cmd)
-
-    # test result
-    assert csvs.nftinfoCsvFilename(CSV_DIR, CHAINID)
-
-
-@enforce_types
-def test_getrate(tmp_path):
-    # insert fake inputs:
-    # <nothing to insert>
-
-    # main cmd
-    TOKEN_SYMBOL = "OCEAN"
-    _ST = "2022-01-01"
-    FIN = "2022-02-02"
-    CSV_DIR = str(tmp_path)
-
-    cmd = f"./dftool getrate {TOKEN_SYMBOL} {_ST} {FIN} {CSV_DIR}"
-    os.system(cmd)
-
-    # test result
-    assert csvs.rateCsvFilenames(CSV_DIR)
 
 
 @enforce_types
@@ -117,39 +85,7 @@ def test_allocations(tmp_path):
     allocations_csv = csvs.allocationCsvFilename(CSV_DIR, False)
     assert os.path.exists(allocations_csv), "allocations_realtime csv not found"
 
-
-@enforce_types
-def test_calc(tmp_path):
-    CSV_DIR = str(tmp_path)
-    OCEAN_addr = oceanutil.OCEAN_address()
-
-    # insert fake csvs
-    allocations = {CHAINID: {"0xpool_addra": {"0xlp_addr1": 1.0}}}
-    csvs.saveAllocationCsv(allocations, CSV_DIR)
-
-    nftvolts_at_chain = {OCEAN_addr: {"0xpool_addra": 1.0}}
-    csvs.saveNftvolsCsv(nftvolts_at_chain, CSV_DIR, CHAINID)
-
-    vebals = {"0xlp_addr1": 1.0}
-    locked_amt = {"0xlp_addr1": 10.0}
-    unlock_time = {"0xlp_addr1": 1}
-    csvs.saveVebalsCsv(vebals, locked_amt, unlock_time, CSV_DIR)
-
-    symbols_at_chain = {OCEAN_addr: "OCEAN"}
-    csvs.saveSymbolsCsv(symbols_at_chain, CSV_DIR, CHAINID)
-
-    csvs.saveRateCsv("OCEAN", 0.50, CSV_DIR)
-
-    # main cmd
-    TOT_OCEAN = 1000.0
-    cmd = f"./dftool calc {CSV_DIR} {TOT_OCEAN}"
-    os.system(cmd)
-
-    # test result
-    rewards_csv = csvs.rewardsperlpCsvFilename(CSV_DIR, "OCEAN")
-    assert os.path.exists(rewards_csv)
-
-
+    
 @enforce_types
 def test_dispense(tmp_path):
     # values used for inputs or main cmd
@@ -187,56 +123,6 @@ def test_dispense(tmp_path):
     # test result
     assert df_rewards.claimable(address1, OCEAN.address) == toBase18(700.0)
     assert df_rewards.claimable(address2, OCEAN.address) == toBase18(300.0)
-
-
-@enforce_types
-def test_manyrandom():
-    cmd = f"./dftool manyrandom {networkutil.DEV_CHAINID}"
-    output_s = ""
-    with subprocess.Popen(
-        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    ) as proc:
-        while proc.poll() is None:
-            output_s += proc.stdout.readline().decode("ascii")
-    return_code = proc.wait()
-    assert return_code == 0, f"Error. \n{output_s}"
-
-
-@enforce_types
-def test_noarg_commands():
-    # Test commands that have no args. They're usually help commands;
-    # sometimes they do the main work (eg compile).
-    argv1s = [
-        "",
-        "query",
-        "volsym",
-        "getrate",
-        "calc",
-        "dispense",
-        "dispense_active",
-        "querymany",
-        "compile",
-        "manyrandom",
-        "newdfrewards",
-        "mine",
-        "newacct",
-        "newtoken",
-        "acctinfo",
-        "chaininfo",
-    ]
-    for argv1 in argv1s:
-        print(f"Test dftool {argv1}")
-        cmd = f"./dftool {argv1}"
-
-        output_s = ""
-        with subprocess.Popen(
-            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        ) as proc:
-            while proc.poll() is None:
-                output_s += proc.stdout.readline().decode("ascii")
-
-        return_code = proc.wait()
-        assert return_code == 0, f"'dftool {argv1}' failed. \n{output_s}"
 
 
 @enforce_types

--- a/util/test/test_dftool2.py
+++ b/util/test/test_dftool2.py
@@ -1,7 +1,6 @@
 # test_dftool1 - lightweight, doesn't need network
 # test_dftool2 - uses network / brownie
 import os
-import subprocess
 import time
 import types
 
@@ -85,7 +84,7 @@ def test_allocations(tmp_path):
     allocations_csv = csvs.allocationCsvFilename(CSV_DIR, False)
     assert os.path.exists(allocations_csv), "allocations_realtime csv not found"
 
-    
+
 @enforce_types
 def test_dispense(tmp_path):
     # values used for inputs or main cmd


### PR DESCRIPTION
Fixes:
- [x] [#425](https://github.com/oceanprotocol/df-py/issues/425) test_dftool.py::setup_function error "ValueError: sender account not recognized"
- [x] [#426](https://github.com/oceanprotocol/df-py/issues/426) Each test_dftool.py test needs 5+ min of setup work, yet most tests don't need to
- [x] [#427](https://github.com/oceanprotocol/df-py/issues/427) oceantestutil.py sets an int for bal_before, when it needs to be a float

