### PR TITLE
Fix #448 - CI fails: API rate limit exceeded

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,12 @@ on:
     branches: [main]
   workflow_call:
 
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
CI fails: 403 when retrieving repo brownie-mix/github-actions 'API rate limit exceeded'

Fixes #448
