### PR TITLE
Finish #411: removed references to "dftool dispense" and "query".

### DIFF
--- a/dftool
+++ b/dftool
@@ -109,7 +109,7 @@ SECRET_SEED -- secret integer used to seed the rng
         RETRIES = int(sys.argv[7])
 
     # extract inputs
-    assert sys.argv[1] == "query" or sys.argv[1] == "volsym"
+    assert sys.argv[1] == "volsym"
     ST, FIN, NSAMP = sys.argv[2], sys.argv[3], int(sys.argv[4])
     CSV_DIR = sys.argv[5]
     CHAINID = int(sys.argv[6])
@@ -420,7 +420,7 @@ Transactions are signed with envvar 'DFTOOL_KEY`.
         sys.exit(0)
 
     # extract inputs
-    assert sys.argv[1] == "dispense" or sys.argv[1] == "dispense_active"
+    assert sys.argv[1] == "dispense_active"
     CSV_DIR = sys.argv[2]
 
     if len(sys.argv) >= 4:
@@ -470,7 +470,7 @@ Transactions are signed with envvar 'DFTOOL_KEY`.
         batch_number=BATCH_NBR,
     )
 
-    print("dftool dispense: Done")
+    print("dftool dispense_active: Done")
 
 
 # ========================================================================
@@ -1051,7 +1051,7 @@ def do_main():
         do_help()
 
     # write actions
-    elif sys.argv[1] == "volsym" or sys.argv[1] == "query":
+    elif sys.argv[1] == "volsym":
         do_volsym()
     elif sys.argv[1] == "nftinfo":
         do_nftinfo()
@@ -1063,7 +1063,7 @@ def do_main():
         do_getrate()
     elif sys.argv[1] == "calc":
         do_calc()
-    elif sys.argv[1] == "dispense" or sys.argv[1] == "dispense_active":
+    elif sys.argv[1] == "dispense_active":
         do_dispense_active()
     elif sys.argv[1] == "compile":
         do_compile()

--- a/dftool
+++ b/dftool
@@ -71,7 +71,6 @@ Usage: dftool getrate|volsym|.. ARG1 ARG2 ..
   dftool newacct - generate new account
   dftool newtoken CHAINID - generate new token (for testing)
 
-
   dftool newVeOcean CHAINID TOKEN_ADDR - deploy veOcean using TOKEN_ADDR (for testing)
   dftool newVeAllocate CHAINID - deploy veAllocate (for testing)
   dftool veSetAllocation CHAINID amount exchangeId - Allocate weight to veAllocate contract. Set to 0 to reset. (for testing)
@@ -1097,11 +1096,9 @@ ARGV_FNS = {
     "help": do_help,
     # write actions
     "compile" : do_compile,
-    "query" : do_volsym,
     "volsym": do_volsym,
     "allocations" : do_allocations,
     "calc" : do_calc,
-    "dispense" : do_dispense_active,
     "dispense_active" : do_dispense_active,
     "dispense_passive" : do_dispense_passive_rewards,
     "calculate_passive" : do_calculate_passive,

--- a/util/test/test_dftool.py
+++ b/util/test/test_dftool.py
@@ -118,11 +118,7 @@ def test_manyrandom():
 def test_noarg_commands():
     # Test commands that have no args. They're usually help commands;
     # sometimes they do the main work (eg compile).
-    argv1s = [
-        "",
-        "compile",
-        "newacct"
-    ]
+    argv1s = ["", "compile", "newacct"]
     for argv1 in argv1s:
         cmd = f"./dftool {argv1}"
 

--- a/util/test/test_dftool.py
+++ b/util/test/test_dftool.py
@@ -118,8 +118,24 @@ def test_manyrandom():
 def test_noarg_commands():
     # Test commands that have no args. They're usually help commands;
     # sometimes they do the main work (eg compile).
-    argv1s = ["", "compile", "newacct"]
+    argv1s = [
+        "",
+        "volsym",
+        "getrate",
+        "calc",
+        "dispense_active",
+        "querymany",
+        "compile",
+        "manyrandom",
+        "newdfrewards",
+        "mine",
+        "newacct",
+        "newtoken",
+        "acctinfo",
+        "chaininfo",
+    ]
     for argv1 in argv1s:
+        print(f"Test dftool {argv1}")
         cmd = f"./dftool {argv1}"
 
         output_s = ""
@@ -131,7 +147,7 @@ def test_noarg_commands():
 
         return_code = proc.wait()
         # bad commands - such as querymany - will still return 0 and do not fail
-        assert return_code == 0, print(f"'dftool {argv1}' failed. \n{output_s}")
+        assert return_code == 0, f"'dftool {argv1}' failed. \n{output_s}"
 
 
 @enforce_types

--- a/util/test/test_dftool.py
+++ b/util/test/test_dftool.py
@@ -120,22 +120,10 @@ def test_noarg_commands():
     # sometimes they do the main work (eg compile).
     argv1s = [
         "",
-        "volsym",
-        "getrate",
-        "calc",
-        "dispense_active",
-        "querymany",
         "compile",
-        "manyrandom",
-        "newdfrewards",
-        "mine",
-        "newacct",
-        "newtoken",
-        "acctinfo",
-        "chaininfo",
+        "newacct"
     ]
     for argv1 in argv1s:
-        print(f"Test dftool {argv1}")
         cmd = f"./dftool {argv1}"
 
         output_s = ""
@@ -146,7 +134,8 @@ def test_noarg_commands():
                 output_s += proc.stdout.readline().decode("ascii")
 
         return_code = proc.wait()
-        assert return_code == 0, f"'dftool {argv1}' failed. \n{output_s}"
+        # bad commands - such as querymany - will still return 0 and do not fail
+        assert return_code == 0, print(f"'dftool {argv1}' failed. \n{output_s}")
 
 
 @enforce_types

--- a/util/test/test_dftool.py
+++ b/util/test/test_dftool.py
@@ -120,11 +120,9 @@ def test_noarg_commands():
     # sometimes they do the main work (eg compile).
     argv1s = [
         "",
-        "query",
         "volsym",
         "getrate",
         "calc",
-        "dispense",
         "dispense_active",
         "querymany",
         "compile",


### PR DESCRIPTION
Finish #411, namely:
>  once all of (3) is clearly working, then deprecate "dftool query" and "dftool dispense"
