### PR TITLE
Updating manyrandom to properly initialize new NFTs + DF

### DIFF
--- a/dftool
+++ b/dftool
@@ -30,6 +30,12 @@ from util.oceanutil import (
     FeeDistributor,
 )
 
+from util.oceantestutil import (
+    randomCreateDataNFTWithFREs,
+    randomLockAndAllocate,
+    randomConsumeFREs,
+)
+
 from util.blocktime import getfinBlock, timestrToTimestamp
 from util.multisig import send_multisig_tx
 
@@ -53,7 +59,7 @@ Usage: dftool getrate|volsym|.. ARG1 ARG2 ..
   dftool dispense_passive CHAINID AMOUNT
 
   dftool compile - compile contracts
-  dftool manyrandom CHAINID - deploy many random tokens & nfts then consume (for testing)
+  dftool manyrandom CHAINID - deploy many random tokens & nfts then + locks fake OCEAN + allocates + consumes (for testing)
   dftool newdfrewards CHAINID - deploy new DFRewards contract
 
   dftool newdfstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_NAME - deploy new DFStrategy
@@ -610,7 +616,7 @@ Usage: dftool compile
 @enforce_types
 def do_manyrandom():
     # UPADATE THIS
-    HELP = f"""Deploy many random tokens & nfts then consume (for testing)
+    HELP = f"""deploy many random tokens & nfts then + locks fake OCEAN + allocates + consumes (for testing)
 
 Usage: dftool manyrandom CHAINID
   CHAINID -- {CHAINID_EXAMPLES}
@@ -644,11 +650,14 @@ ADDRESS_FILE -- eg: export ADDRESS_FILE={networkutil.chainIdToAddressFile(chainI
 
     # main work
     recordDeployedContracts(ADDRESS_FILE)
-    oceantestutil.fillAccountsWithOCEAN()
+    OCEAN = OCEANtoken()
+
     num_nfts = 10  # magic number
-    # This fn was deprecated, replace.
-    # oceantestutil.randomDeployTokensAndPoolsThenConsume(num_pools, OCEANtoken())
+    tups = randomCreateDataNFTWithFREs(num_nfts, OCEAN, brownie.network.accounts)
+    randomLockAndAllocate(tups)
+    randomConsumeFREs(tups, OCEAN)
     print(f"dftool manyrandom: Done. {num_nfts} new nfts created.")
+
 
 
 # ========================================================================

--- a/dftool
+++ b/dftool
@@ -59,7 +59,7 @@ Usage: dftool getrate|volsym|.. ARG1 ARG2 ..
   dftool dispense_passive CHAINID AMOUNT
 
   dftool compile - compile contracts
-  dftool manyrandom CHAINID - deploy many random tokens & nfts then + locks fake OCEAN + allocates + consumes (for testing)
+  dftool manyrandom CHAINID - deploy many datatokens + locks OCEAN + allocates + consumes (for testing)
   dftool newdfrewards CHAINID - deploy new DFRewards contract
 
   dftool newdfstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_NAME - deploy new DFStrategy
@@ -616,7 +616,7 @@ Usage: dftool compile
 @enforce_types
 def do_manyrandom():
     # UPADATE THIS
-    HELP = f"""deploy many random tokens & nfts then + locks fake OCEAN + allocates + consumes (for testing)
+    HELP = f"""deploy many datatokens + locks OCEAN + allocates + consumes (for testing)
 
 Usage: dftool manyrandom CHAINID
   CHAINID -- {CHAINID_EXAMPLES}
@@ -627,8 +627,6 @@ ADDRESS_FILE -- eg: export ADDRESS_FILE={networkutil.chainIdToAddressFile(chainI
     if len(sys.argv) not in [3]:
         print(HELP)
         sys.exit(0)
-
-    from util import oceantestutil  # pylint: disable=import-outside-toplevel
 
     # extract inputs
     assert sys.argv[1] == "manyrandom"


### PR DESCRIPTION
- deploys many random tokens & nfts then + locks fake OCEAN + allocates + consumes (for testing)
As described in https://github.com/oceanprotocol/df-py/pull/313
