### PR TITLE
Ensure gas costs are not duplicated

### DIFF
--- a/util/query.py
+++ b/util/query.py
@@ -490,7 +490,7 @@ def _queryVolsOwners(
                     gasvols[native_token_addr][nft_addr] = 0
 
                 if order["tx"] not in txgascost:
-                    txgascost["tx"] = gasCost
+                    txgascost[order["tx"]] = gasCost
                     gasvols[native_token_addr][nft_addr] += gasCost
 
             if lastPriceValue == 0:


### PR DESCRIPTION
Fixes #524

Changes proposed in this PR:

- Ensure that gas costs are not duplicated when multiple orders share the same transaction hash.