### PR TITLE
Add minimal dispense_passive tests

### DIFF
--- a/util/test/test_dftool_noganache.py
+++ b/util/test/test_dftool_noganache.py
@@ -1,9 +1,10 @@
 import os
 import subprocess
 from typing import List
+from unittest.mock import patch
 
-from enforce_typing import enforce_types
 import pytest
+from enforce_typing import enforce_types
 
 from util import csvs, dftool_module
 
@@ -40,7 +41,7 @@ def test_gen_hist_data():
 @enforce_types
 def test_noarg_commands():
     # Test commands that have no args
-    subargs = _get_HELP_SHORT_subargs_in_dftool()  # key args only, for speed
+    subargs = _get_HELP_subargs_in_dftool("HELP_SHORT")  # key args only, for speed
     subargs = [""] + ["badarg"] + subargs
 
     # these commands are intended to have no parameters
@@ -64,9 +65,10 @@ def test_noarg_commands():
 
 
 @enforce_types
-def _get_HELP_SHORT_subargs_in_dftool() -> List[str]:
+def _get_HELP_subargs_in_dftool(help_type) -> List[str]:
     """Return e.g. ["help", "compile", "getrate", "volsym", ...]"""
-    s_lines = dftool_module.HELP_SHORT.split("\n")
+    help_content = getattr(dftool_module, help_type)
+    s_lines = help_content.split("\n")
 
     subargs = []
     for s_line in s_lines:
@@ -79,3 +81,15 @@ def _get_HELP_SHORT_subargs_in_dftool() -> List[str]:
 
     assert "compile" in subargs  # postcondition
     return subargs
+
+
+@enforce_types
+def test_functions_exist():
+    functions = _get_HELP_subargs_in_dftool("HELP_LONG")
+    functions.remove("help")  # maps to help_short
+
+    for function in functions:
+        with patch("util.dftool_module.do_" + function):
+            # patch can only overwrite existing functions
+            # so that ensures the function exists
+            pass

--- a/util/test/test_dispense.py
+++ b/util/test/test_dispense.py
@@ -6,6 +6,7 @@ from util import dispense, networkutil, oceanutil
 from util.base18 import from_wei
 from util.constants import BROWNIE_PROJECT as B
 from util import oceantestutil
+from unittest.mock import patch
 
 accounts, a1, a2, a3 = None, None, None, None
 
@@ -85,6 +86,16 @@ def test_batch_number():
     assert df_rewards.claimable(accounts[batch_size + 1], TOK.address) > 0
     assert df_rewards.claimable(accounts[batch_size + 2], TOK.address) > 0
     assert df_rewards.claimable(accounts[batch_size + 3], TOK.address) == 0
+
+
+def test_dispense_passive():
+    feedist = oceanutil.FeeDistributor()
+    OCEAN = oceanutil.OCEANtoken()
+    with patch("util.dispense.chainIdToMultisigAddr"):
+        with patch("util.dispense.send_multisig_tx") as mock:
+            dispense.dispense_passive(OCEAN, feedist, 1)
+
+    assert mock.call_count == 3
 
 
 @enforce_types

--- a/util/test/test_dispense.py
+++ b/util/test/test_dispense.py
@@ -1,12 +1,12 @@
-import brownie
-from enforce_typing import enforce_types
-import pytest
+from unittest.mock import patch
 
-from util import dispense, networkutil, oceanutil
+import brownie
+import pytest
+from enforce_typing import enforce_types
+
+from util import dispense, networkutil, oceantestutil, oceanutil
 from util.base18 import from_wei
 from util.constants import BROWNIE_PROJECT as B
-from util import oceantestutil
-from unittest.mock import patch
 
 accounts, a1, a2, a3 = None, None, None, None
 


### PR DESCRIPTION
Fixes #616.
Since the issue found by Alex was in fact an issue with the command missing, I added assertions that all the functions (corresponding to each help entry) exist in dftool_module.