### PR TITLE
Adds argument parsing

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -119,14 +119,14 @@ jobs:
           USE_MULTISIG: true
         if: github.event_name != 'schedule'
         run: |
-          ./dftool dispense_active $CSV_DIR 5 0x6fd867E5AEE6D62a24f97939db90C4e67A73A651 0xCfDdA22C9837aE76E0faA845354f33C62E03653a
+          ./dftool dispense_active $CSV_DIR 5 --DFREWARDS_ADDR=0x6fd867E5AEE6D62a24f97939db90C4e67A73A651 --TOKEN_ADDR=0xCfDdA22C9837aE76E0faA845354f33C62E03653a
 
       - name: Distribute active rewards
         env:
           USE_MULTISIG: true
         if: github.event_name == 'schedule'
         run: |
-          ./dftool dispense_active $CSV_DIR 1 0xFe27534EA0c016634b2DaA97Ae3eF43fEe71EEB0 0x967da4048cD07aB37855c090aAF366e4ce1b9F48
+          ./dftool dispense_active $CSV_DIR 1 --DFREWARDS_ADDR=0xFe27534EA0c016634b2DaA97Ae3eF43fEe71EEB0 --TOKEN_ADDR=0x967da4048cD07aB37855c090aAF366e4ce1b9F48
 
       - name: Rename folder to round number
         run: |

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -81,9 +81,9 @@ jobs:
 
       - name: Run dftool getrate
         run: |
-          ./dftool getrate OCEAN $date $now $CSV_DIR $RETRY_TIMES
-          ./dftool getrate ETH $date $now $CSV_DIR $RETRY_TIMES
-          ./dftool getrate MATIC $date $now $CSV_DIR $RETRY_TIMES
+          ./dftool getrate OCEAN $date $now $CSV_DIR --RETRIES $RETRY_TIMES
+          ./dftool getrate ETH $date $now $CSV_DIR --RETRIES $RETRY_TIMES
+          ./dftool getrate MATIC $date $now $CSV_DIR --RETRIES $RETRY_TIMES
 
       - name: Run dftool volsym
         run: |

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -92,11 +92,11 @@ jobs:
 
       - name: Run dftool vebals
         run: |
-          ./dftool vebals $date $now 200 $CSV_DIR 1 $RETRY_TIMES
+          ./dftool vebals $date $now 200 $CSV_DIR 1 --RETRIES $RETRY_TIMES
 
       - name: Run dftool allocations
         run: |
-          ./dftool allocations $date $now 200 $CSV_DIR 1 $RETRY_TIMES
+          ./dftool allocations $date $now 200 $CSV_DIR 1 --RETRIES $RETRY_TIMES
 
       - name: Run sed
         run: |

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Run dftool volsym
         run: |
-          ./dftool volsym $date $now 200 $CSV_DIR 1 $RETRY_TIMES
-          ./dftool volsym $date $now 200 $CSV_DIR 137 $RETRY_TIMES
+          ./dftool volsym $date $now 200 $CSV_DIR 1 --RETRIES $RETRY_TIMES
+          ./dftool volsym $date $now 200 $CSV_DIR 137 --RETRIES $RETRY_TIMES
 
       - name: Run dftool vebals
         run: |

--- a/.github/workflows/test-dfsql.yml
+++ b/.github/workflows/test-dfsql.yml
@@ -100,7 +100,7 @@ jobs:
   
       - name: Run dftool nftinfo
         run: |
-          ./dftool nftinfo $CSV_DIR 1 $TEST_END_DATE
+          ./dftool nftinfo $CSV_DIR 1 --FIN $TEST_END_DATE
 
       - name: Run sed
         run: |

--- a/.github/workflows/test-dfsql.yml
+++ b/.github/workflows/test-dfsql.yml
@@ -92,11 +92,11 @@ jobs:
   
       - name: Run dftool vebals
         run: |
-          ./dftool vebals $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 $RETRY_TIMES
+          ./dftool vebals $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 --RETRIES $RETRY_TIMES
   
       - name: Run dftool allocations
         run: |
-          ./dftool allocations $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 $RETRY_TIMES
+          ./dftool allocations $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 --RETRIES $RETRY_TIMES
   
       - name: Run dftool nftinfo
         run: |

--- a/.github/workflows/test-dfsql.yml
+++ b/.github/workflows/test-dfsql.yml
@@ -83,7 +83,7 @@ jobs:
   
       - name: Run dftool getrate
         run: |
-          ./dftool getrate OCEAN $TEST_START_DATE $TEST_END_DATE $CSV_DIR $RETRY_TIMES
+          ./dftool getrate OCEAN $TEST_START_DATE $TEST_END_DATE $CSV_DIR --RETRIES $RETRY_TIMES
   
       - name: Run dftool volsym
         run: |

--- a/.github/workflows/test-dfsql.yml
+++ b/.github/workflows/test-dfsql.yml
@@ -87,8 +87,8 @@ jobs:
   
       - name: Run dftool volsym
         run: |
-          ./dftool volsym $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 $RETRY_TIMES
-          ./dftool volsym $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 137 $RETRY_TIMES
+          ./dftool volsym $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 1 --RETRIES $RETRY_TIMES
+          ./dftool volsym $TEST_START_DATE $TEST_END_DATE 2 $CSV_DIR 137 --RETRIES $RETRY_TIMES
   
       - name: Run dftool vebals
         run: |

--- a/df-system/scripts/all.sh
+++ b/df-system/scripts/all.sh
@@ -13,18 +13,18 @@ dfpy_docker getrate OCEAN $date $now /app/data
 dfpy_docker getrate ETH $date $now /app/data
 dfpy_docker getrate MATIC $date $now /app/data
 
-dfpy_docker volsym $date latest 50 /app/data 1 && 
+dfpy_docker volsym $date latest 50 /app/data 1 &&
 dfpy_docker volsym $date latest 50 /app/data 137 &&
 
 dfpy_docker vebals  $date latest 50 /app/data 1 &&
 dfpy_docker vebals  $date latest 1 /app/data 1 &&
-dfpy_docker allocations $date latest 50 /app/data 1 
+dfpy_docker allocations $date latest 50 /app/data 1
 dfpy_docker allocations $date latest 1 /app/data 1
 
 cp /tmp/dfpy/rate-OCEAN.csv /tmp/dfpy/rate-MOCEAN.csv
 sed -i -e 's/MOCEAN/OCEAN/g' /tmp/dfpy/rate-MOCEAN.csv
 
-dfpy_docker calc /app/data 0 $date OCEAN
+dfpy_docker calc volume /app/data 0 $date OCEAN
 
 dfpy_docker calculate_passive 1 $date /app/data
 

--- a/df_py/challenge/judge.py
+++ b/df_py/challenge/judge.py
@@ -3,7 +3,7 @@
 import os
 from calendar import WEDNESDAY
 from datetime import datetime, timedelta, timezone
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import ccxt
 import numpy as np
@@ -124,7 +124,7 @@ def _get_cex_vals(deadline_dt):
 
 
 @enforce_types
-def parse_deadline_str(deadline_str: str) -> datetime:
+def parse_deadline_str(deadline_str: Optional[str] = None) -> datetime:
     """
     @arguments
       deadline_str - submission deadline
@@ -135,7 +135,7 @@ def parse_deadline_str(deadline_str: str) -> datetime:
     @return
       deadline_dt -- datetime object, in UTC
     """
-    if deadline_str == "None":
+    if deadline_str is None:
         today = datetime.now(timezone.utc)
         today = today.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/df_py/challenge/test/test_dftool_challenge.py
+++ b/df_py/challenge/test/test_dftool_challenge.py
@@ -16,48 +16,30 @@ ADDRESS_FILE = networkutil.chainIdToAddressFile(CHAINID)
 
 @enforce_types
 def test1(tmp_path):
-    _test(tmp_path, DEADLINE=None, RETRIES=None)
+    _test(tmp_path, DEADLINE=None)
 
 
 @enforce_types
 def test2(tmp_path):
-    _test(tmp_path, DEADLINE="None", RETRIES=None)
+    _test(tmp_path, DEADLINE="None")
 
 
 @enforce_types
 def test3(tmp_path):
-    _test(tmp_path, DEADLINE="None", RETRIES=2)
+    _test(tmp_path, DEADLINE="2023-05-03_23:59")
 
 
 @enforce_types
-def test4(tmp_path):
-    _test(tmp_path, DEADLINE="2023-05-03_23:59", RETRIES=None)
-
-
-@enforce_types
-def test5(tmp_path):
-    _test(tmp_path, DEADLINE="2023-05-03_23:59", RETRIES=2)
-
-
-@enforce_types
-def _test(tmp_path, DEADLINE: Optional[str], RETRIES: Optional[int]):
+def _test(tmp_path, DEADLINE: Optional[str]):
     # build base cmd
     base_dir = str(tmp_path)
     CSV_DIR = os.path.join(base_dir, judge.DFTOOL_TEST_FAKE_CSVDIR)
     os.mkdir(CSV_DIR)
     cmd = f"./dftool challenge_data {CSV_DIR}"
 
-    # tack on 1 or 2 args to cmd as needed
-    if DEADLINE is None and RETRIES is None:
-        pass
-    elif DEADLINE is None and RETRIES is not None:
-        assert ValueError("must specify DEADLINE if RETRIES is not None")
-    elif DEADLINE is not None and RETRIES is None:
-        cmd += f" {DEADLINE}"
-    elif DEADLINE is not None and RETRIES is not None:
-        cmd += f" {DEADLINE} {RETRIES}"
-    else:
-        raise AssertionError("shouldn't end up here")
+    # DEADLINE option to cmd as needed
+    if DEADLINE is not None:
+        cmd += f" --DEADLINE {DEADLINE}"
 
     # main call
     print(f"CMD: {cmd}")

--- a/df_py/challenge/test/test_judge.py
+++ b/df_py/challenge/test/test_judge.py
@@ -83,7 +83,7 @@ def test_parse_deadline_str1():
 
 @enforce_types
 def test_parse_deadline_str2():
-    dt = judge.parse_deadline_str("None")
+    dt = judge.parse_deadline_str()
 
     assert (datetime.now(timezone.utc) - dt) < timedelta(days=7)  # within 1 wk
     assert dt.weekday() == 2  # Mon is 0, Tue is 1, Wed is 2

--- a/df_py/tests/stress.py
+++ b/df_py/tests/stress.py
@@ -140,7 +140,7 @@ def main():
     df_rewards = B.DFRewards.deploy({"from": accounts[0]})
     DFREWARDS_ADDR = df_rewards.address
     TOKEN_ADDR = OCEAN.address
-    cmd = f"./dftool dispense_active {CSV_DIR} {CHAINID} {DFREWARDS_ADDR} {TOKEN_ADDR}"
+    cmd = f"./dftool dispense_active {CSV_DIR} {CHAINID} --DFREWARDS_ADDR={DFREWARDS_ADDR} --TOKEN_ADDR={TOKEN_ADDR}"
     os.system(cmd)
 
     claimable_amounts = []

--- a/df_py/util/dftool_arguments.py
+++ b/df_py/util/dftool_arguments.py
@@ -61,11 +61,6 @@ Transactions are signed with envvar 'DFTOOL_KEY`.
 
 
 @enforce_types
-def do_help():
-    do_help_long()
-
-
-@enforce_types
 def do_help_short(status_code=0):
     print(HELP_SHORT)
     sys.exit(status_code)
@@ -145,6 +140,7 @@ def challenge_date(s):
 
     try:
         judge.parse_deadline_str(s)
+        return s
     except Exception as e:  # pylint: disable=bare-except
         raise argparse.ArgumentTypeError(str(e)) from e
 

--- a/df_py/util/dftool_arguments.py
+++ b/df_py/util/dftool_arguments.py
@@ -1,0 +1,226 @@
+# pylint: disable=too-many-lines,too-many-statements
+import argparse
+import datetime
+import os
+import sys
+
+from enforce_typing import enforce_types
+
+from df_py.challenge import judge
+from df_py.util.networkutil import DEV_CHAINID
+
+CHAINID_EXAMPLES = (
+    f"{DEV_CHAINID} for development, 1 for (eth) mainnet, 137 for polygon"
+)
+
+# ========================================================================
+HELP_SHORT = """Data Farming tool, for use by OPF.
+
+Usage: dftool compile|getrate|volsym|.. ARG1 ARG2 ..
+
+  dftool help - full command list
+
+  dftool compile - compile contracts
+  dftool getrate TOKEN_SYMBOL ST FIN CSV_DIR --RETRIES
+  dftool volsym ST FIN NSAMP CSV_DIR CHAINID --RETRIES - query chain, output volumes, symbols, owners
+  dftool allocations ST FIN NSAMP CSV_DIR CHAINID --RETRIES
+  dftool vebals ST FIN NSAMP CSV_DIR CHAINID --RETRIES
+  dftool challenge_data CSV_DIR [DEADLINE] --RETRIES
+  dftool predictoor_data CSV_DIR START_DATE END_DATE CHAINID --RETRIES
+  dftool calc CSV_DIR TOT_OCEAN [START_DATE] [IGNORED] - from stakes/etc csvs, output rewards csvs across Volume + Challenge + Predictoor DF
+  dftool dispense_active CSV_DIR CHAINID --DFREWARDS_ADDR --TOKEN_ADDR --BATCH_NBR - from rewards, dispense funds
+  dftool dispense_passive CHAINID AMOUNT
+  dftool nftinfo CSV_DIR CHAINID -- Query chain, output nft info csv
+"""
+
+HELP_LONG = (
+    HELP_SHORT
+    + """
+  dftool newacct - generate new account
+  dftool initdevwallets CHAINID - Init wallets with OCEAN. (GANACHE ONLY)
+  dftool newtoken CHAINID - generate new token (for testing)
+  dftool acctinfo CHAINID ACCOUNT_ADDR [TOKEN_ADDR] - info about an account
+  dftool chaininfo CHAINID - info about a network
+
+  dftool mine BLOCKS --TIMEDELTA - force chain to pass time (ganache only)
+
+  dftool newVeOcean CHAINID TOKEN_ADDR - deploy veOcean using TOKEN_ADDR (for testing)
+  dftool newVeAllocate CHAINID - deploy veAllocate (for testing)
+  dftool veSetAllocation CHAINID amount exchangeId - Allocate weight to veAllocate contract. Set to 0 to reset. (for testing)
+
+  dftool manyrandom CHAINID - deploy many datatokens + locks OCEAN + allocates + consumes (for testing)
+  dftool newdfrewards CHAINID - deploy new DFRewards contract
+  dftool newdfstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_NAME - deploy new DFStrategy
+  dftool addstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_ADDR - Add a strategy to DFRewards contract
+  dftool retirestrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_ADDR - Retire a strategy from DFRewards contract
+  dftool checkpoint_feedist CHAINID - checkpoint FeeDistributor contract
+
+Transactions are signed with envvar 'DFTOOL_KEY`.
+"""
+)
+
+
+@enforce_types
+def do_help():
+    do_help_long()
+
+
+@enforce_types
+def do_help_short(status_code=0):
+    print(HELP_SHORT)
+    sys.exit(status_code)
+
+
+@enforce_types
+def do_help_long(status_code=0):
+    print(HELP_LONG)
+    sys.exit(status_code)
+
+
+def valid_date_and_convert(s):
+    try:
+        return datetime.datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        pass
+
+    msg = "not a valid date: {s}"
+    raise argparse.ArgumentTypeError(msg)
+
+
+def valid_date(s):
+    try:
+        datetime.datetime.strptime(s, "%Y-%m-%d")
+        return s
+    except ValueError:
+        pass
+
+    msg = "not a valid date: {s}"
+    raise argparse.ArgumentTypeError(msg)
+
+
+def block_or_valid_date(s):
+    if s == "latest":
+        return s
+
+    try:
+        return int(s)
+    except ValueError:
+        pass
+
+    try:
+        datetime.datetime.strptime(s, "%Y-%m-%d")
+        return s
+    except ValueError:
+        pass
+
+    try:
+        datetime.datetime.strptime(s, "%Y-%m-%d_%H:%M")
+        return s
+    except ValueError:
+        pass
+
+    msg = "not a valid date or block number: {s}"
+    raise argparse.ArgumentTypeError(msg)
+
+
+def existing_path(s):
+    if not os.path.exists(s):
+        msg = f"Directory {s} doesn't exist."
+        raise argparse.ArgumentTypeError(msg)
+
+    return s
+
+
+def autocreate_path(s):
+    if not os.path.exists(s):
+        print(f"Directory {s} did not exist, so created it")
+        os.mkdir(s)
+
+    return s
+
+
+def challenge_date(s):
+    if s == "None":
+        return None
+
+    try:
+        judge.parse_deadline_str(s)
+    except Exception as e:  # pylint: disable=bare-except
+        raise argparse.ArgumentTypeError(str(e)) from e
+
+
+def print_arguments(arguments):
+    arguments_dict = arguments.__dict__
+    command = arguments_dict.pop("command", None)
+
+    print(f"dftool {command}: Begin")
+    print("Arguments:")
+
+    for arg_k, arg_v in arguments_dict.items():
+        print(f"{arg_k}={arg_v}")
+
+
+class StartFinArgumentParser(argparse.ArgumentParser):
+    def __init__(self, description, epilog, command_name, csv_name):
+        super().__init__(
+            description=description,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=epilog,
+        )
+        self.add_argument("command", choices=[command_name])
+        self.add_argument(
+            "ST",
+            type=block_or_valid_date,
+            help="first block # to calc on | YYYY-MM-DD | YYYY-MM-DD_HH:MM",
+        )
+        self.add_argument(
+            "FIN",
+            type=block_or_valid_date,
+            help="last block # to calc on | YYYY-MM-DD | YYYY-MM-DD_HH:MM | latest",
+        )
+        self.add_argument(
+            "NSAMP",
+            type=int,
+            help="blocks to sample liquidity from, from blocks [ST, ST+1, .., FIN]",
+        )
+        self.add_argument(
+            "CSV_DIR",
+            type=existing_path,
+            help=f"output dir for {csv_name}-CHAINID.csv, etc",
+        )
+        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
+        self.add_argument(
+            "--RETRIES",
+            default=1,
+            type=int,
+            help="# times to retry failed queries",
+            required=False,
+        )
+
+
+class SimpleChainIdArgumentParser(argparse.ArgumentParser):
+    def __init__(self, description, command_name, epilog=None):
+        super().__init__(
+            description=description,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=epilog,
+        )
+        self.add_argument("command", choices=[command_name])
+        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
+
+    def print_args_and_get_chain(self):
+        arguments = self.parse_args()
+        print_arguments(arguments)
+
+        return arguments.CHAINID
+
+
+class DfStrategyArgumentParser(argparse.ArgumentParser):
+    def __init__(self, description, command_name):
+        super().__init__(description=description)
+        self.add_argument("command", choices=[command_name])
+        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
+        self.add_argument("DFREWARDS_ADDR", type=str, help="DFRewards contract address")
+        self.add_argument(
+            "DFSTRATEGY_ADDR", type=str, help="DFStrategy contract address"
+        )

--- a/df_py/util/dftool_arguments.py
+++ b/df_py/util/dftool_arguments.py
@@ -157,7 +157,7 @@ def print_arguments(arguments):
 
 
 class StartFinArgumentParser(argparse.ArgumentParser):
-    def __init__(self, description, epilog, command_name, csv_name):
+    def __init__(self, description, epilog, command_name, csv_names):
         super().__init__(
             description=description,
             formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -182,7 +182,7 @@ class StartFinArgumentParser(argparse.ArgumentParser):
         self.add_argument(
             "CSV_DIR",
             type=existing_path,
-            help=f"output dir for {csv_name}-CHAINID.csv, etc",
+            help=f"output dir for {csv_names}",
         )
         self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
         self.add_argument(

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -25,7 +25,6 @@ from df_py.util.dftool_arguments import (
     autocreate_path,
     block_or_valid_date,
     challenge_date,
-    do_help,
     do_help_long,
     do_help_short,
     existing_path,
@@ -530,6 +529,7 @@ def do_dispense_active():
         "--BATCH_NBR",
         default=None,
         type=str,
+        # pylint: disable=line-too-long
         help="specify the batch number to run dispense only for that batch. If not given, runs dispense for all batches.",
         required=False,
     )
@@ -658,7 +658,8 @@ def do_compile():
 def do_initdevwallets():
     # UPADATE THIS
     parser = SimpleChainIdArgumentParser(
-        "Init wallets with OCEAN. (GANACHE ONLY)" "initdevwallets",
+        "Init wallets with OCEAN. (GANACHE ONLY)",
+        "initdevwallets",
         epilog=f"""Uses these envvars:
           ADDRESS_FILE -- eg: export ADDRESS_FILE={networkutil.chainIdToAddressFile(chainID=DEV_CHAINID)}
         """,

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -62,7 +62,7 @@ def do_volsym():
           \nSECRET_SEED -- secret integer used to seed the rng
         """,
         command_name="volsym",
-        csv_name="stakes",
+        csv_names="nftvols-CHAINID.csv, owners-CHAINID.csv, symbols-CHAINID.csv",
     )
 
     arguments = parser.parse_args()
@@ -156,7 +156,7 @@ def do_allocations():
           \nSECRET_SEED -- secret integer used to seed the rng
         """,
         command_name="allocations",
-        csv_name="stakes",
+        csv_names="allocations.csv or allocations_realtime.csv",
     )
 
     arguments = parser.parse_args()
@@ -197,7 +197,7 @@ def do_vebals():
           \nSECRET_SEED -- secret integer used to seed the rng
         """,
         command_name="vebals",
-        csv_name="stakes",
+        csv_names="vebals.csv or vebals_realtime.csv",
     )
     arguments = parser.parse_args()
     print_arguments(arguments)
@@ -1091,6 +1091,10 @@ def _getPrivateAccount():
 def _do_main():
     if len(sys.argv) == 1:
         do_help_short(1)
+        return
+
+    if len(sys.argv[1]) == "help":
+        do_help_long(1)
         return
 
     func_name = f"do_{sys.argv[1]}"

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -17,6 +17,22 @@ from df_py.util import blockrange, constants, dispense, getrate, networkutil
 from df_py.util.base18 import from_wei
 from df_py.util.blocktime import getfinBlock, getstfinBlocks, timestrToTimestamp
 from df_py.util.constants import BROWNIE_PROJECT as B
+from df_py.util.dftool_arguments import (
+    CHAINID_EXAMPLES,
+    DfStrategyArgumentParser,
+    SimpleChainIdArgumentParser,
+    StartFinArgumentParser,
+    autocreate_path,
+    block_or_valid_date,
+    challenge_date,
+    do_help,
+    do_help_long,
+    do_help_short,
+    existing_path,
+    print_arguments,
+    valid_date,
+    valid_date_and_convert,
+)
 from df_py.util.multisig import send_multisig_tx
 from df_py.util.networkutil import DEV_CHAINID, chainIdToMultisigAddr
 from df_py.util.oceantestutil import (
@@ -37,224 +53,7 @@ from df_py.volume.vesting_schedule import getActiveRewardAmountForWeekEth
 
 brownie.network.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
-CHAINID_EXAMPLES = (
-    f"{DEV_CHAINID} for development, 1 for (eth) mainnet, 137 for polygon"
-)
 
-# ========================================================================
-HELP_SHORT = """Data Farming tool, for use by OPF.
-
-Usage: dftool compile|getrate|volsym|.. ARG1 ARG2 ..
-
-  dftool help - full command list
-
-  dftool compile - compile contracts
-  dftool getrate TOKEN_SYMBOL ST FIN CSV_DIR [RETRIES]
-  dftool volsym ST FIN NSAMP CSV_DIR CHAINID [RETRIES] - query chain, output volumes, symbols, owners
-  dftool allocations ST FIN NSAMP CSV_DIR CHAINID [RETRIES]
-  dftool vebals ST FIN NSAMP CSV_DIR CHAINID [RETRIES]
-  dftool challenge_data CSV_DIR [DEADLINE] [RETRIES]
-  dftool predictoor_data CSV_DIR START_DATE END_DATE CHAINID [RETRIES]
-  dftool calc CSV_DIR TOT_OCEAN [START_DATE] [IGNORED] - from stakes/etc csvs, output rewards csvs across Volume + Challenge + Predictoor DF
-  dftool dispense_active CSV_DIR [CHAINID] [DFREWARDS_ADDR] [TOKEN_ADDR] [BATCH_NBR] - from rewards, dispense funds
-  dftool dispense_passive CHAINID AMOUNT
-  dftool nftinfo CSV_DIR CHAINID -- Query chain, output nft info csv
-"""
-
-HELP_LONG = (
-    HELP_SHORT
-    + """
-  dftool newacct - generate new account
-  dftool initdevwallets CHAINID - Init wallets with OCEAN. (GANACHE ONLY)
-  dftool newtoken CHAINID - generate new token (for testing)
-  dftool acctinfo CHAINID ACCOUNT_ADDR [TOKEN_ADDR] - info about an account
-  dftool chaininfo CHAINID - info about a network
-
-  dftool mine BLOCKS [TIMEDELTA] - force chain to pass time (ganache only)
-
-  dftool newVeOcean CHAINID TOKEN_ADDR - deploy veOcean using TOKEN_ADDR (for testing)
-  dftool newVeAllocate CHAINID - deploy veAllocate (for testing)
-  dftool veSetAllocation CHAINID amount exchangeId - Allocate weight to veAllocate contract. Set to 0 to reset. (for testing)
-
-  dftool manyrandom CHAINID - deploy many datatokens + locks OCEAN + allocates + consumes (for testing)
-  dftool newdfrewards CHAINID - deploy new DFRewards contract
-  dftool newdfstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_NAME - deploy new DFStrategy
-  dftool addstrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_ADDR - Add a strategy to DFRewards contract
-  dftool retirestrategy CHAINID DFREWARDS_ADDR DFSTRATEGY_ADDR - Retire a strategy from DFRewards contract
-  dftool checkpoint_feedist CHAINID - checkpoint FeeDistributor contract
-
-Transactions are signed with envvar 'DFTOOL_KEY`.
-"""
-)
-
-
-@enforce_types
-def do_help():
-    do_help_long()
-
-
-@enforce_types
-def do_help_short(status_code=0):
-    print(HELP_SHORT)
-    sys.exit(status_code)
-
-
-@enforce_types
-def do_help_long(status_code=0):
-    print(HELP_LONG)
-    sys.exit(status_code)
-
-
-def valid_date_and_convert(s):
-    try:
-        return datetime.datetime.strptime(s, "%Y-%m-%d")
-    except ValueError:
-        pass
-
-    msg = "not a valid date: {s}"
-    raise argparse.ArgumentTypeError(msg)
-
-
-def valid_date(s):
-    try:
-        datetime.datetime.strptime(s, "%Y-%m-%d")
-        return s
-    except ValueError:
-        pass
-
-    msg = "not a valid date: {s}"
-    raise argparse.ArgumentTypeError(msg)
-
-
-def block_or_valid_date(s):
-    if s == "latest":
-        return s
-
-    try:
-        return int(s)
-    except ValueError:
-        pass
-
-    try:
-        datetime.datetime.strptime(s, "%Y-%m-%d")
-        return s
-    except ValueError:
-        pass
-
-    try:
-        datetime.datetime.strptime(s, "%Y-%m-%d_%H:%M")
-        return s
-    except ValueError:
-        pass
-
-    msg = "not a valid date or block number: {s}"
-    raise argparse.ArgumentTypeError(msg)
-
-
-def existing_path(s):
-    if not os.path.exists(s):
-        msg = f"Directory {s} doesn't exist."
-        raise argparse.ArgumentTypeError(msg)
-
-    return s
-
-
-def autocreate_path(s):
-    if not os.path.exists(s):
-        print(f"Directory {s} did not exist, so created it")
-        os.mkdir(s)
-
-    return s
-
-
-def challenge_date(s):
-    if s == "None":
-        return None
-
-    try:
-        judge.parse_deadline_str(s)
-    except Exception as e:  # pylint: disable=bare-except
-        raise argparse.ArgumentTypeError(str(e)) from e
-
-
-def print_arguments(arguments):
-    arguments_dict = arguments.__dict__
-    command = arguments_dict.pop("command", None)
-
-    print(f"dftool {command}: Begin")
-    print("Arguments:")
-
-    for arg_k, arg_v in arguments_dict.items():
-        print(f"{arg_k}={arg_v}")
-
-
-class StartFinArgumentParser(argparse.ArgumentParser):
-    def __init__(self, description, epilog, command_name, csv_name):
-        super().__init__(
-            description=description,
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            epilog=epilog,
-        )
-        self.add_argument("command", choices=[command_name])
-        self.add_argument(
-            "ST",
-            type=block_or_valid_date,
-            help="first block # to calc on | YYYY-MM-DD | YYYY-MM-DD_HH:MM",
-        )
-        self.add_argument(
-            "FIN",
-            type=block_or_valid_date,
-            help="last block # to calc on | YYYY-MM-DD | YYYY-MM-DD_HH:MM | latest",
-        )
-        self.add_argument(
-            "NSAMP",
-            type=int,
-            help="blocks to sample liquidity from, from blocks [ST, ST+1, .., FIN]",
-        )
-        self.add_argument(
-            "CSV_DIR",
-            type=existing_path,
-            help=f"output dir for {csv_name}-CHAINID.csv, etc",
-        )
-        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
-        self.add_argument(
-            "--RETRIES",
-            default=1,
-            type=int,
-            help="# times to retry failed queries",
-            required=False,
-        )
-
-
-class SimpleChainIdArgumentParser(argparse.ArgumentParser):
-    def __init__(self, description, command_name, epilog=None):
-        super().__init__(
-            description=description,
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            epilog=epilog,
-        )
-        self.add_argument("command", choices=[command_name])
-        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
-
-    def print_args_and_get_chain(self):
-        arguments = self.parse_args()
-        print_arguments(arguments)
-
-        return arguments.CHAINID
-
-
-class DfStrategyArgumentParser(argparse.ArgumentParser):
-    def __init__(self, description, command_name):
-        super().__init__(description=description)
-        self.add_argument("command", choices=[command_name])
-        self.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
-        self.add_argument("DFREWARDS_ADDR", type=str, help="DFRewards contract address")
-        self.add_argument(
-            "DFSTRATEGY_ADDR", type=str, help="DFStrategy contract address"
-        )
-
-
-# ========================================================================
 @enforce_types
 def do_volsym():
     parser = StartFinArgumentParser(

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -532,6 +532,7 @@ def do_predictoor_data():
         type=autocreate_path,
         help="output directory for predictoordata_CHAINID.csv",
     )
+    parser.add_argument("CHAINID", type=int, help=CHAINID_EXAMPLES)
     parser.add_argument(
         "--RETRIES",
         default=1,

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -1093,8 +1093,8 @@ def _do_main():
         do_help_short(1)
         return
 
-    if len(sys.argv[1]) == "help":
-        do_help_long(1)
+    if sys.argv[1] == "help":
+        do_help_long(0)
         return
 
     func_name = f"do_{sys.argv[1]}"

--- a/df_py/util/test/test_dftool_ganache.py
+++ b/df_py/util/test/test_dftool_ganache.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import subprocess
-import sys
 from unittest.mock import patch
 
 import brownie
@@ -172,6 +171,7 @@ def test_dispense(tmp_path):
     DFREWARDS_ADDR = df_rewards.address
     OCEAN_ADDR = oceanutil.OCEAN_address()
 
+    # pylint: disable=line-too-long
     cmd = f"./dftool dispense_active {CSV_DIR} {CHAINID} --DFREWARDS_ADDR={DFREWARDS_ADDR} --TOKEN_ADDR={OCEAN_ADDR}"
     os.system(cmd)
 

--- a/df_py/util/test/test_dftool_ganache.py
+++ b/df_py/util/test/test_dftool_ganache.py
@@ -56,16 +56,29 @@ def test_calc(tmp_path):
     assert os.path.exists(rewards_csv)
 
 
+class MockArgs:
+    def __init__(self, dictionary):
+        for k, v in dictionary.items():
+            setattr(self, k, v)
+
+
 @enforce_types
 def test_predictoor_data(tmp_path):
     CSV_DIR = str(tmp_path)
-    ST = 0
-    FIN = "latest"
-
-    testargs = ["dftool", "predictoor_data", CSV_DIR, ST, FIN, CHAINID]
+    testargs = MockArgs(
+        {
+            "command": "predictoor_data",
+            "ST": 0,
+            "FIN": "latest",
+            "CSV_DIR": CSV_DIR,
+            "CHAINID": CHAINID,
+            "RETRIES": 1,
+        }
+    )
     mock_query_response, users, stats = create_mock_responses(100)
 
-    with patch.object(sys, "argv", testargs):
+    with patch("argparse.ArgumentParser.parse_args") as mock_args:
+        mock_args.return_value = testargs
         with patch("df_py.predictoor.queries.submitQuery") as mock_submitQuery:
             mock_submitQuery.side_effect = mock_query_response
             do_predictoor_data()

--- a/df_py/util/test/test_dftool_ganache.py
+++ b/df_py/util/test/test_dftool_ganache.py
@@ -159,7 +159,7 @@ def test_dispense(tmp_path):
     DFREWARDS_ADDR = df_rewards.address
     OCEAN_ADDR = oceanutil.OCEAN_address()
 
-    cmd = f"./dftool dispense_active {CSV_DIR} {CHAINID} {DFREWARDS_ADDR} {OCEAN_ADDR}"
+    cmd = f"./dftool dispense_active {CSV_DIR} {CHAINID} --DFREWARDS_ADDR={DFREWARDS_ADDR} --TOKEN_ADDR={OCEAN_ADDR}"
     os.system(cmd)
 
     # test result

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from enforce_typing import enforce_types
 
-from df_py.util import dftool_module
+from df_py.util import dftool_arguments
 from df_py.volume import csvs
 
 
@@ -46,7 +46,7 @@ def test_noarg_commands():
     subargs = [""] + ["badarg"] + subargs
 
     # these commands are intended to have no parameters
-    fail_gracefully = ["help", "compile"]
+    fail_gracefully = ["compile"]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")
@@ -70,7 +70,7 @@ def test_noarg_commands():
 @enforce_types
 def _get_HELP_subargs_in_dftool(help_type) -> List[str]:
     """Return e.g. ["help", "compile", "getrate", "volsym", ...]"""
-    help_content = getattr(dftool_module, help_type)
+    help_content = getattr(dftool_arguments, help_type)
     s_lines = help_content.split("\n")
 
     subargs = []

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -48,7 +48,7 @@ def test_noarg_commands():
     # these commands are intended to have no parameters
     fail_gracefully = ["help", "compile"]
     # TODO: in order for tests to pass until we convert to argparse fully
-    uses_argparse = ["volsym", "nftinfo"]
+    uses_argparse = ["volsym", "nftinfo", "allocations", "vebals"]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -48,7 +48,14 @@ def test_noarg_commands():
     # these commands are intended to have no parameters
     fail_gracefully = ["help", "compile"]
     # TODO: in order for tests to pass until we convert to argparse fully
-    uses_argparse = ["volsym", "nftinfo", "allocations", "vebals"]
+    uses_argparse = [
+        "volsym",
+        "nftinfo",
+        "allocations",
+        "vebals",
+        "getrate",
+        "challenge_data",
+    ]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -46,7 +46,7 @@ def test_noarg_commands():
     subargs = [""] + ["badarg"] + subargs
 
     # these commands are intended to have no parameters
-    fail_gracefully = ["compile"]
+    fail_gracefully = ["help", "compile"]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -47,6 +47,8 @@ def test_noarg_commands():
 
     # these commands are intended to have no parameters
     fail_gracefully = ["help", "compile"]
+    # TODO: in order for tests to pass until we convert to argparse fully
+    uses_argparse = ["volsym", "nftinfo"]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")
@@ -60,8 +62,15 @@ def test_noarg_commands():
                 output_s += proc.stdout.readline().decode("ascii")
 
         return_code = proc.wait()
-        assert return_code == (
-            0 if subarg in fail_gracefully else 1
+        if subarg in fail_gracefully:
+            expected_return_code = 0
+        elif subarg in uses_argparse:
+            expected_return_code = 2
+        else:
+            expected_return_code = 1
+
+        assert (
+            return_code == expected_return_code
         ), f"'dftool {subarg}' failed. \n{output_s}"
 
 

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -55,6 +55,8 @@ def test_noarg_commands():
         "vebals",
         "getrate",
         "challenge_data",
+        "predictoor_data",
+        "dispense_active",
     ]
 
     for subarg in subargs:

--- a/df_py/util/test/test_dftool_noganache.py
+++ b/df_py/util/test/test_dftool_noganache.py
@@ -47,17 +47,6 @@ def test_noarg_commands():
 
     # these commands are intended to have no parameters
     fail_gracefully = ["help", "compile"]
-    # TODO: in order for tests to pass until we convert to argparse fully
-    uses_argparse = [
-        "volsym",
-        "nftinfo",
-        "allocations",
-        "vebals",
-        "getrate",
-        "challenge_data",
-        "predictoor_data",
-        "dispense_active",
-    ]
 
     for subarg in subargs:
         print(f"CMD: dftool {subarg}")
@@ -71,16 +60,11 @@ def test_noarg_commands():
                 output_s += proc.stdout.readline().decode("ascii")
 
         return_code = proc.wait()
-        if subarg in fail_gracefully:
-            expected_return_code = 0
-        elif subarg in uses_argparse:
-            expected_return_code = 2
-        else:
-            expected_return_code = 1
 
-        assert (
-            return_code == expected_return_code
-        ), f"'dftool {subarg}' failed. \n{output_s}"
+        if subarg in fail_gracefully:
+            assert return_code == 0
+        else:
+            assert return_code in [1, 2]
 
 
 @enforce_types

--- a/df_py/util/test/test_goerli.py
+++ b/df_py/util/test/test_goerli.py
@@ -36,7 +36,7 @@ def test_main(tmp_path):
     ACCOUNT_ADDR = "0xc945a5a960fef1a9c3fef8593fc2446d1d7c6146"
     TOKEN_ADDR = "0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6"
     fn = os.path.join(tmp_path, "out.txt")
-    cmd = f"./dftool acctinfo {CHAINID} {ACCOUNT_ADDR} {TOKEN_ADDR}>{fn} 2>{fn}"
+    cmd = f"./dftool acctinfo {CHAINID} {ACCOUNT_ADDR} --TOKEN_ADDR={TOKEN_ADDR}>{fn} 2>{fn}"
     os.system(cmd)
 
     s = None

--- a/df_py/volume/test/test_queries.py
+++ b/df_py/volume/test/test_queries.py
@@ -332,7 +332,7 @@ def _test_dftool_nftinfo(tmp_path, FIN):
     CSV_DIR = str(tmp_path)
     _clear_dir(CSV_DIR)
 
-    cmd = f"./dftool nftinfo {CSV_DIR} {CHAINID} {FIN}"
+    cmd = f"./dftool nftinfo {CSV_DIR} {CHAINID} --FIN {FIN}"
     os.system(cmd)
 
     assert csvs.nftinfoCsvFilename(CSV_DIR, CHAINID)

--- a/scripts/gen_hist_data.sh
+++ b/scripts/gen_hist_data.sh
@@ -53,15 +53,15 @@ if [ $USE_TESTNET -eq 1 ]; then
     dftool query $date $now $SAMPLES $CSV_DIR 80001
     dftool vebals $date $now $SAMPLES $CSV_DIR 5
     dftool allocations $date $now $SAMPLES $CSV_DIR 5
-    dftool nftinfo $CSV_DIR 5 $now
-    dftool nftinfo $CSV_DIR 80001 $now
+    dftool nftinfo $CSV_DIR 5 --FIN $now
+    dftool nftinfo $CSV_DIR 80001 --FIN $now
 else
     dftool query $date $now $SAMPLES $CSV_DIR 1
     dftool query $date $now $SAMPLES $CSV_DIR 137
     dftool vebals $date $now $SAMPLES $CSV_DIR 1
     dftool allocations $date $now $SAMPLES $CSV_DIR 1
-    dftool nftinfo $CSV_DIR 1 $now
-    dftool nftinfo $CSV_DIR 137 $now
+    dftool nftinfo $CSV_DIR 1 --FIN $now
+    dftool nftinfo $CSV_DIR 137 --FIN $now
 fi
 
 


### PR DESCRIPTION
Work on #640.

Accomplishments:
- tighter argument parsing, no need to count arguments manually
- optional arguments are now actually options, not arguments -> easier management of defaults and no more reliance on ordering and other missing/present args/options
- automatic validation of parameters through reusable functions e.g. for ST and FIN blocks, for CSV paths (and auto-created if needed)
- reusable classes of arguments for commands that share the same set of arguments and options
- automatic help formatting: no need for HELP strings since argparse shows the exact needed thing if an argument is missed
one-liner parameter printing, e.g. `dftool volsym -h`, `dftool volsym --help`
- argument parsing is in a separate file, improving readability and Separation of Concerns principle for dftool_module
- fixed some older typos and unused variables (which we did not realise at the time because the code was more complex)

BONUS/metrics: dftool_module is ~330 lines shorter, with BETTER functionality than before.

I have NOT touched `calc` to avoid conflicts. We need to convert that one too. That is why I marked my PR as "work on" instead of "closes".