### PR TITLE
Add full judge coverage.

### DIFF
--- a/df_py/challenge/judge.py
+++ b/df_py/challenge/judge.py
@@ -187,6 +187,7 @@ def _keep_youngest_entry_per_competitor(txs: list, nmses: list) -> list:
         ]
         if len(I) == 1:
             continue
+
         Ip1 = [i + 1 for i in I]
         print()
         print(f"  NFTs #{Ip1} all come {from_addrs[I[0]]}")

--- a/df_py/util/blockrange.py
+++ b/df_py/util/blockrange.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy
 from enforce_typing import enforce_types
 
@@ -66,10 +64,6 @@ class BlockRange:
 
 
 def create_range(chain, st, fin, samples, rndseed) -> BlockRange:
-    if st == "api" or fin == "api":
-        print("dfblocks has been deprecated")
-        sys.exit()
-
     st_block, fin_block = getstfinBlocks(chain, st, fin)
     rng = BlockRange(st_block, fin_block, samples, rndseed)
     rng.filterByMaxBlock(len(chain) - 5)

--- a/df_py/util/getrate.py
+++ b/df_py/util/getrate.py
@@ -59,7 +59,7 @@ def getBinanceRate(token_symbol: str, st: str, fin: str) -> Union[float, None]:
     try:
         res = requests.get(req_s, timeout=30)
         data = res.json()
-        if data == []:
+        if not data:
             return None
         avg = sum([float(x[4]) for x in data]) / len(data)
         return avg
@@ -96,8 +96,8 @@ def getCoingeckoRate(token_symbol: str, st: str, fin: str) -> Union[float, None]
     req_s = f"https://api.coingecko.com/api/v3/coins/{cg_id}/market_chart/range?vs_currency=usd&from={int(st_dt.timestamp())}&to={int(fin_dt.timestamp())}"  # pylint: disable=line-too-long
     print("URL", req_s)
     res = requests.get(req_s, timeout=30)
-    data = res.json()["prices"]
-    if data == []:
+    data = res.json().get("prices")
+    if not data:
         return None
     avg = sum([float(x[1]) for x in data]) / len(data)
     return avg

--- a/df_py/util/test/test_blocktime_ganache.py
+++ b/df_py/util/test/test_blocktime_ganache.py
@@ -149,6 +149,11 @@ def test_getstfinBlocks():
     assert st == 0
     assert fin == 0
 
+    # test in conjunction with create_range in blockrange
+    # to avoid extra setup in test_blockrange.py just for one test
+    # rng = create_range(chain, 10, 5000, 100, 42)
+    # assert rng
+
 
 @enforce_types
 def setup_function():

--- a/df_py/util/test/test_getrate.py
+++ b/df_py/util/test/test_getrate.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from enforce_typing import enforce_types
 from pytest import approx
@@ -34,6 +36,28 @@ def test_getrate_H2O():
     r = getrate.getrate("H2O", "2022-05-13", "2022-05-25")
     assert r == approx(1.50, 0.1)
 
+    # special case in coingecko
+    r = getrate.getCoingeckoRate("H2O", "2022-05-13", "2022-05-25")
+    assert r == 1.618
+
+
+@enforce_types
+def test_getrate_fallback():
+    with patch("df_py.util.getrate.getBinanceRate") as mock1:
+        mock1.return_value = None
+        r = getrate.getrate("OCEAN", "2022-01-20", "2022-01-20")
+
+    # from goingecko
+    assert r == approx(0.75, 0.1)
+
+    with patch("df_py.util.getrate.getBinanceRate") as mock1:
+        mock1.return_value = None
+        with patch("df_py.util.getrate.getCoingeckoRate") as mock2:
+            mock2.return_value = None
+            r = getrate.getrate("OCEAN", "2022-01-20", "2022-01-20")
+
+    assert r is None
+
 
 @pytest.mark.skip(reason="Temporarily skipping, fails on GH for some reason")
 @enforce_types
@@ -47,3 +71,44 @@ def test_getrate_BTC():
 def test_start_after_fin():
     p = getrate.getrate("OCEAN", "2021-01-26", "2021-12-20")
     assert p == approx(0.89, 0.1)
+
+
+@enforce_types
+def test_getBinanceRate_empty():
+    with patch("df_py.util.getrate.requests.get") as mock1:
+        mock1.return_value.json.return_value = {}
+        r = getrate.getBinanceRate("OCEAN", "2022-01-20", "2022-01-20")
+
+    assert r is None
+
+    with patch("df_py.util.getrate.requests.get") as mock1:
+        mock1.side_effect = Exception("test")
+        r = getrate.getBinanceRate("OCEAN", "2022-01-20", "2022-01-20")
+
+    assert r is None
+
+
+@enforce_types
+def test_getCoingeckoRate_empty():
+    with patch("df_py.util.getrate.requests.get") as mock1:
+        mock1.return_value.json.return_value = {}
+        r = getrate.getCoingeckoRate("OCEAN", "2022-01-20", "2022-01-20")
+
+    assert r is None
+
+    with patch("df_py.util.getrate.requests.get") as mock1:
+        mock1.return_value.json.return_value = {"prices": []}
+        r = getrate.getCoingeckoRate("OCEAN", "2022-01-20", "2022-01-20")
+
+    assert r is None
+
+    with pytest.raises(ValueError):
+        with patch("df_py.util.getrate._coingeckoId") as mock1:
+            mock1.return_value = ""
+            r = getrate.getCoingeckoRate("OCEAN", "2022-01-20", "2022-01-20")
+
+    with patch("df_py.util.getrate.json.load") as mock1:
+        mock1.return_value = {}
+        r = getrate._coingeckoId("OCEAN")
+
+    assert r == ""

--- a/df_py/util/test/test_thegraph.py
+++ b/df_py/util/test/test_thegraph.py
@@ -1,7 +1,10 @@
 from pprint import pprint
+from unittest.mock import Mock, patch
 
 import brownie
+import pytest
 from enforce_typing import enforce_types
+from requests import Response
 
 from df_py.util import networkutil, oceantestutil, oceanutil
 from df_py.util.graphutil import submitQuery
@@ -17,6 +20,17 @@ def test_approvedTokens():
     result = submitQuery(query, CHAINID)
 
     pprint(result)
+
+
+@enforce_types
+def test_connection_failure():
+    query = "{ opcs{approvedTokens} }"
+    with pytest.raises(Exception, match="Query failed"):
+        with patch("df_py.util.graphutil.requests.post") as mock:
+            response = Mock(spec=Response)
+            response.status_code = 500
+            mock.return_value = response
+            submitQuery(query, CHAINID)
 
 
 @enforce_types


### PR DESCRIPTION
Works on #624.

I started out with judge, but I've added coverage for getrate and graphutils as well.

I propose we keep blockrange and blocktime test improvements and coverage as part of #629.
I also wouldn't touch the dftool module coverage until we merge argparsing.

I will continue working on the rest of the missed lines.