### PR TITLE
Accurate gas distribution across assets consumed within the same tx

### DIFF
--- a/df_py/volume/queries.py
+++ b/df_py/volume/queries.py
@@ -450,7 +450,10 @@ def _queryNftinfo(chainID, endBlock) -> List[SimpleDataNft]:
 
     return nftinfo
 
-def _calculate_gas_vols(txgascost: Dict[str, Dict[str, float]], native_token_addr: str) -> Dict[str, Dict[str, float]]:
+
+def _calculate_gas_vols(
+    txgascost: Dict[str, Dict[str, float]], native_token_addr: str
+) -> Dict[str, Dict[str, float]]:
     """
     @description
       Calculate the gas volumes attributed to each NFT based on shared transaction gas costs.
@@ -476,6 +479,7 @@ def _calculate_gas_vols(txgascost: Dict[str, Dict[str, float]], native_token_add
             gasvols[native_token_addr].setdefault(nft, 0)
             gasvols[native_token_addr][nft] += gas_attributed
     return gasvols
+
 
 @enforce_types
 def _queryVolsOwners(

--- a/df_py/volume/test/test_queries.py
+++ b/df_py/volume/test/test_queries.py
@@ -1061,14 +1061,13 @@ def test_calculate_gas_vols_distributes_gas_evenly():
     }
     native_token_addr = "token1"
 
-    expected_gasvols = {
-        "token1": {"nft1": 50.0, "nft2": 150.0, "nft3": 200.0}
-    }
+    expected_gasvols = {"token1": {"nft1": 50.0, "nft2": 150.0, "nft3": 200.0}}
 
     calculated_gasvols = queries._calculate_gas_vols(txgascost, native_token_addr)
 
-    assert calculated_gasvols == expected_gasvols, "Gas volumes should be evenly distributed among NFTs."
-
+    assert (
+        calculated_gasvols == expected_gasvols
+    ), "Gas volumes should be evenly distributed among NFTs."
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #737

Changes proposed in this PR:

- Added _calculate_gas_vols function and tests
- Use _calculate_gas_vols function in _queryVolsOwners to accurately calculate the amount of gas used per nft.