### PR TITLE
Fix #815: [SW eng, CI] pylint df_py/* fails 

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -29,3 +29,4 @@ jobs:
       - name: Run Pylint
         run: |
           pylint --recursive=true --rcfile .pylintrc *
+          pylint --rcfile .pylintrc df_py/* 

--- a/df_py/volume/allocations.py
+++ b/df_py/volume/allocations.py
@@ -1,7 +1,8 @@
+from typing import Tuple
+
 from enforce_typing import enforce_types
 
 from df_py.volume import cleancase, csvs
-from typing import Tuple
 
 
 @enforce_types

--- a/df_py/volume/queries.py
+++ b/df_py/volume/queries.py
@@ -214,7 +214,7 @@ def queryVebalances(
             offset += chunk_size
         n_blocks_sampled += 1
 
-    # TODO: this assertion doesn't work with nsamples = 1, failing in test_queries all
+    # TO DO: this assertion doesn't work with nsamples = 1, failing in test_queries all
     # assert n_blocks_sampled > 0
 
     # get average
@@ -312,7 +312,7 @@ def queryAllocations(
             offset += chunk_size
         n_blocks_sampled += 1
 
-    # TODO: this assertion doesn't work with nsamples = 1, failing in test_queries all
+    # TO DO: this assertion doesn't work with nsamples = 1, failing in test_queries all
     # assert n_blocks_sampled > 0
 
     # get average
@@ -456,28 +456,27 @@ def _calculate_gas_vols(
 ) -> Dict[str, Dict[str, float]]:
     """
     @description
-      Calculate the gas volumes attributed to each NFT based on shared transaction gas costs.
+      Calculate gas volumes attribute to each NFT based on shared tx gas costs.
 
     @arguments
-      txgascost (Dict[str, Dict[str, float]]): A dictionary mapping transaction hashes to another dictionary,
-        where the inner dictionary maps NFT addresses to their tx associated gas costs.
-      native_token_addr (str): The address of the native token used to pay for gas.
+      txgascost -- dict of [tx_hash][nft_addr] -- gas_cost_float
+      native_token_addr -- address of native token used to pay for gas
 
     @return
-      Dict[str, Dict[str, float]]: A dictionary mapping the native token address to another dictionary,
-        where the inner dictionary maps NFT addresses to the gas volumes attributed to them.
+      gasvols -- dict of [tx_hash][nft_addr] -- gas_vol_float
     """
     gasvols: Dict[str, Dict[str, float]] = {}
     gasvols[native_token_addr] = {}
     for tx in txgascost:
-        nfts = txgascost[tx].keys()
+        nft_addrs = txgascost[tx].keys()
         gas_cost = list(txgascost[tx].values())[0]
-        tot_nfts = len(nfts)
-        gas_attributed = gas_cost / tot_nfts
+        n_nfts = len(nft_addrs)
+        gas_attributed = gas_cost / n_nfts
 
-        for nft in nfts:
-            gasvols[native_token_addr].setdefault(nft, 0)
-            gasvols[native_token_addr][nft] += gas_attributed
+        for nft_addr in nft_addrs:
+            gasvols[native_token_addr].setdefault(nft_addr, 0)
+            gasvols[native_token_addr][nft_addr] += gas_attributed
+
     return gasvols
 
 

--- a/df_py/volume/reward_calculator.py
+++ b/df_py/volume/reward_calculator.py
@@ -30,6 +30,7 @@ def freeze_attributes(func):
     return wrapper
 
 
+# pylint: disable=too-many-instance-attributes
 class RewardCalculator:
     def __setattr__(self, attr, value):
         if getattr(self, "_freeze_attributes", False) and attr != "_freeze_attributes":
@@ -91,6 +92,8 @@ class RewardCalculator:
         self.M: np.ndarray
         self.R: np.ndarray
         self.L: np.ndarray
+
+        self.C: np.ndarray
 
         self._freeze_attributes = True
 
@@ -375,14 +378,15 @@ class RewardCalculator:
           predictoor_feed_addrs -- dict of (chainID, list of nft_addrs)
 
         @notes
-          This will only return the prediction feeds that are owned by DEPLOYER_ADDRS, due to functionality of query_predictoor_contracts().
+          This will only return the prediction feeds that are owned by
+          DEPLOYER_ADDRS, due to functionality of query_predictoor_contracts().
         """
         chainIDs = list(self.stakes.keys())
         predictoor_feed_addrs: Dict[int, List[str]] = {
             chain_id: [] for chain_id in chainIDs
         }
 
-        for chain_id in DEPLOYER_ADDRS.keys():
+        for chain_id in DEPLOYER_ADDRS:
             predictoor_feed_addrs[chain_id] = query_predictoor_contracts(
                 chain_id
             ).keys()

--- a/df_py/volume/test/test_calcrewards.py
+++ b/df_py/volume/test/test_calcrewards.py
@@ -1,5 +1,6 @@
+# pylint: disable=too-many-lines
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -42,7 +43,7 @@ QUERY_PATH = "df_py.volume.reward_calculator.query_predictoor_contracts"
 
 class MockRewardCalculator(RewardCalculator):
     def __init__(self):
-        return super().__init__({}, {}, {}, {}, {}, {}, DF_WEEK, False, False, False)
+        super().__init__({}, {}, {}, {}, {}, {}, DF_WEEK, False, False, False)
 
     def set_mock_attribute(self, attr_name, attr_value):
         self._freeze_attributes = False
@@ -59,10 +60,10 @@ def test_freeze_attributes():
     rc._freeze_attributes = True
 
     with pytest.raises(AttributeError):
-        rc.new_attr = 1
+        rc.new_attr = 1  # pylint: disable=attribute-defined-outside-init
 
     rc._freeze_attributes = False
-    rc.new_attr = 1
+    rc.new_attr = 1  # pylint: disable=attribute-defined-outside-init
 
 
 @patch(QUERY_PATH, MagicMock(return_value={}))
@@ -835,6 +836,7 @@ def _plot_ranks(save_or_show, max_n_rank_assets, rank_scale_op):
     N = 120
     V_USD = np.arange(N, 0, -1)  # N, N-1, ..., 2, 1. Makes ranking obvious!
 
+    # pylint: disable=undefined-variable
     p = _rank_based_allocate(
         V_USD, max_n_rank_assets=max_n_rank_assets, rank_scale_op=rank_scale_op
     )
@@ -1101,7 +1103,8 @@ def test_volume_reward_calculator_no_pdrs(tmp_path):
         # OCEAN_reward was 1000
         # volumes were 300 (NA) & 600 (NB), for 900 total
         # Since fee multiplier is 1.0, DCV bound is 300 for NA, 600 for NB
-        # Therefore DCV bound is the constraint on rewards # Therefore 300 OCEAN goes to NA, 600 goes to NB
+        # Therefore DCV bound is the constraint on rewards
+        # Therefore 300 OCEAN goes to NA, 600 goes to NB
 
         # NA's LPs are {LP1}, therefore LP1 gets all 300 OCEAN
         assert rewards_per_lp[C1][LP1] == 300
@@ -1137,7 +1140,7 @@ def test_volume_reward_calculator_pdr_mul(tmp_path):
 
     predictoor_contracts = {NA: {}}
 
-    def mock_multipliers(DF_week, is_predictoor):
+    def mock_multipliers(DF_week, is_predictoor):  # pylint: disable=unused-argument
         if not is_predictoor:
             return MagicMock(return_value=1)
         return 0.201


### PR DESCRIPTION
Fixes #815

 - have a second call in remote CI, for: `pylint --rcfile .pylintrc df_py/*`
 - fix all the pylint errors