### PR TITLE
Towards #812: carve out functionality from reward_calculator.py

### DIFF
--- a/df_py/predictoor/test/test_predictoor_calc_rewards.py
+++ b/df_py/predictoor/test/test_predictoor_calc_rewards.py
@@ -10,7 +10,7 @@ from df_py.predictoor.calc_rewards import (
 )
 from df_py.predictoor.models import Prediction, Predictoor, PredictoorBase
 from df_py.util.networkutil import DEV_CHAINID
-from df_py.volume.reward_calculator import RewardShaper
+from df_py.util.reward_shaper import RewardShaper
 
 
 @pytest.fixture(autouse=True)

--- a/df_py/util/dcv_multiplier.py
+++ b/df_py/util/dcv_multiplier.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from enforce_typing import enforce_types
+import numpy as np
+
+from df_py.util.constants import PREDICTOOR_MULTIPLIER
+
+
+@enforce_types
+def get_df_week_number(dt: datetime) -> int:
+    """Return the DF week number. This is used by boundRewardsByDcv().
+    There was a gap from DF4 to DF5. Since we only care about future dates,
+    don't bother to properly support this gap, just focus on future.
+    """
+    DF5_start = datetime(2022, 9, 29)  # Thu Sep 29
+    if dt < DF5_start:
+        return -1
+
+    days_offset = (dt - DF5_start).days
+    weeks_offset = days_offset // 7
+    DF_week = weeks_offset + 1 + 4
+    return DF_week
+
+
+@enforce_types
+def calc_dcv_multiplier(DF_week: int, is_predictoor: bool) -> float:
+    """
+    Calculate DCV multiplier, for use in bounding rewards_avail by DCV
+
+    @arguments
+      DF_week -- e.g. 9 for DF9
+
+    @return
+      DCV_multiplier --
+    """
+    if is_predictoor:
+        return PREDICTOOR_MULTIPLIER
+
+    if DF_week < 9:
+        return np.inf
+
+    if 9 <= DF_week <= 28:
+        return -0.0485 * (DF_week - 9) + 1.0
+
+    return 0.001

--- a/df_py/util/dftool_module.py
+++ b/df_py/util/dftool_module.py
@@ -57,7 +57,7 @@ from df_py.util.vesting_schedule import (
     get_active_reward_amount_for_week_eth_by_stream,
 )
 from df_py.volume import csvs, queries
-from df_py.volume.reward_calculator import RewardShaper
+from df_py.util.reward_shaper import RewardShaper
 from df_py.volume.calc_rewards import calc_volume_rewards_from_csvs
 
 

--- a/df_py/util/reward_shaper.py
+++ b/df_py/util/reward_shaper.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+from enforce_typing import enforce_types
+
+
+class RewardShaper:
+    @staticmethod
+    @enforce_types
+    def flatten(rewards: Dict[int, Dict[str, float]]) -> Dict[str, float]:
+        """
+        @arguments
+          rewards -- dict of [chainID][LP_addr] : reward_float
+
+        @return
+          flats -- dict of [LP_addr] : reward_float
+        """
+        flats: Dict[str, float] = {}
+        for chainID in rewards:
+            for LP_addr in rewards[chainID]:
+                flats[LP_addr] = flats.get(LP_addr, 0.0) + rewards[chainID][LP_addr]
+
+        return flats
+
+    @staticmethod
+    def merge(*reward_dicts):
+        merged_dict = {}
+
+        for reward_dict in reward_dicts:
+            for key, value in reward_dict.items():
+                merged_dict[key] = merged_dict.get(key, 0) + value
+
+        return merged_dict

--- a/df_py/util/test/test_dcv_multiplier.py
+++ b/df_py/util/test/test_dcv_multiplier.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta
+
+from enforce_typing import enforce_types
+import numpy as np
+import pytest
+
+from df_py.util.dcv_multiplier import get_df_week_number, calc_dcv_multiplier
+
+
+@enforce_types
+def test_get_df_week_number():
+    wk_nbr = get_df_week_number
+
+    # test DF5. Counting starts Thu Sep 29, 2022. Last day is Wed Oct 5, 2022
+    assert wk_nbr(datetime(2022, 9, 28)) == -1  # Wed
+    assert wk_nbr(datetime(2022, 9, 29)) == 5  # Thu
+    assert wk_nbr(datetime(2022, 9, 30)) == 5  # Fri
+    assert wk_nbr(datetime(2022, 10, 5)) == 5  # Wed
+    assert wk_nbr(datetime(2022, 10, 6)) == 6  # Thu
+    assert wk_nbr(datetime(2022, 10, 12)) == 6  # Wed
+    assert wk_nbr(datetime(2022, 10, 13)) == 7  # Thu
+
+    # test DF9. Start Thu Oct 27. Last day is Wed Nov 2, 2022,
+    assert wk_nbr(datetime(2022, 10, 25)) == 8  # Wed
+    assert wk_nbr(datetime(2022, 10, 26)) == 8  # Wed
+    assert wk_nbr(datetime(2022, 10, 27)) == 9  # Thu
+    assert wk_nbr(datetime(2022, 10, 28)) == 9  # Fri
+    assert wk_nbr(datetime(2022, 11, 2)) == 9  # Wed
+    assert wk_nbr(datetime(2022, 11, 3)) == 10  # Thu
+    assert wk_nbr(datetime(2022, 11, 4)) == 10  # Fri
+
+    # test many weeks
+    start_dt = datetime(2022, 9, 29)
+    for wks_offset in range(50):
+        true_wk = wks_offset + 1 + 4
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=1)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=2)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=3)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=4)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=5)) == true_wk
+        assert wk_nbr(start_dt + timedelta(weeks=wks_offset, days=6)) == true_wk
+
+    # test extremes
+    assert wk_nbr(datetime(2000, 1, 1)) == -1
+    assert wk_nbr(datetime(2022, 6, 14)) == -1
+    assert wk_nbr(datetime(2022, 6, 15)) == -1
+    assert 50 < wk_nbr(datetime(2030, 1, 1)) < 10000
+    assert 50 < wk_nbr(datetime(2040, 1, 1)) < 10000
+
+
+@enforce_types
+def test_calc_dcv_multiplier():
+    mult = calc_dcv_multiplier
+
+    assert mult(-10, False) == np.inf
+    assert mult(-1, False) == np.inf
+    assert mult(0, False) == np.inf
+    assert mult(1, False) == np.inf
+    assert mult(8, False) == np.inf
+    assert mult(9, False) == 1.0
+    assert mult(10, False) == pytest.approx(0.951, 0.001)
+    assert mult(11, False) == pytest.approx(0.903, 0.001)
+    assert mult(12, False) == pytest.approx(0.854, 0.001)
+    assert mult(20, False) == pytest.approx(0.4665, 0.001)
+    assert mult(27, False) == pytest.approx(0.127, 0.001)
+    assert mult(28, False) == pytest.approx(0.0785, 0.001)
+    assert mult(29, False) == 0.001
+    assert mult(30, False) == 0.001
+    assert mult(31, False) == 0.001
+    assert mult(100, False) == 0.001
+    assert mult(10000, False) == 0.001
+
+    assert mult(-10, True) == 0.201
+    assert mult(9, True) == 0.201
+    assert mult(12, True) == 0.201
+    assert mult(10000, True) == 0.201

--- a/df_py/util/test/test_reward_shaper.py
+++ b/df_py/util/test/test_reward_shaper.py
@@ -1,0 +1,63 @@
+from enforce_typing import enforce_types
+
+from df_py.util.reward_shaper import RewardShaper
+
+C1, C2, C3 = 7, 137, 1285  # chainIDs
+LP1, LP2, LP3 = "0xlp1_addr", "0xlp2_addr", "0xlp3_addr"
+
+
+@enforce_types
+def test_flatten_rewards():
+    rewards = {
+        C1: {
+            LP1: 100.0,
+            LP2: 200.0,
+        },
+        C2: {
+            LP1: 300.0,
+        },
+        C3: {
+            LP1: 500.0,
+            LP2: 600.0,
+            LP3: 700.0,
+        },
+    }
+
+    flat_rewards = RewardShaper.flatten(rewards)
+    assert flat_rewards == {
+        LP1: 100.0 + 300.0 + 500.0,
+        LP2: 200.0 + 600.0,
+        LP3: 700.0,
+    }
+
+
+@enforce_types
+def test_merge_rewards():
+    # Test case 1: Merge two reward dictionaries with no common keys
+    dict1 = {"A": 10, "B": 20}
+    dict2 = {"C": 30, "D": 40}
+    expected_output = {"A": 10, "B": 20, "C": 30, "D": 40}
+    assert RewardShaper.merge(dict1, dict2) == expected_output
+
+    # Test case 2: Merge two reward dictionaries with common keys
+    dict1 = {"A": 10, "B": 20}
+    dict2 = {"B": 30, "C": 40}
+    expected_output = {"A": 10, "B": 50, "C": 40}
+    assert RewardShaper.merge(dict1, dict2) == expected_output
+
+    # Test case 3: Merge three reward dictionaries with common keys
+    dict1 = {"A": 10, "B": 20}
+    dict2 = {"B": 30, "C": 40}
+    dict3 = {"A": 50, "C": 60}
+    expected_output = {"A": 60, "B": 50, "C": 100}
+    assert RewardShaper.merge(dict1, dict2, dict3) == expected_output
+
+    # Test case 4: Merge empty reward dictionary
+    dict1 = {"A": 10, "B": 20}
+    dict2 = {}
+    expected_output = {"A": 10, "B": 20}
+    assert RewardShaper.merge(dict1, dict2) == expected_output
+
+    # Test case 5: Merge no reward dictionaries
+    expected_output = {}
+    assert RewardShaper.merge() == expected_output

--- a/df_py/util/vesting_schedule.py
+++ b/df_py/util/vesting_schedule.py
@@ -11,7 +11,7 @@ from df_py.util.constants import (
     PREDICTOOR_OCEAN_BUDGET,
     PREDICTOOR_RELEASE_WEEK,
 )
-from df_py.volume.reward_calculator import get_df_week_number
+from df_py.util.dcv_multiplier import get_df_week_number
 
 
 @enforce_types

--- a/df_py/volume/calc_rewards.py
+++ b/df_py/volume/calc_rewards.py
@@ -5,9 +5,10 @@ from typing import Dict, Optional, Union
 from enforce_typing import enforce_types
 
 from df_py.util.constants import DO_PUBREWARDS, DO_RANK
+from df_py.util.dcv_multiplier import get_df_week_number
 from df_py.util.graphutil import wait_to_latest_block
 from df_py.volume import allocations, csvs
-from df_py.volume.reward_calculator import RewardCalculator, get_df_week_number
+from df_py.volume.reward_calculator import RewardCalculator
 
 
 @enforce_types
@@ -45,6 +46,7 @@ def calc_volume_rewards_from_csvs(
     csvs.save_volume_rewardsinfo_csv(rewinfo, str(csv_dir))
 
 
+@enforce_types
 def calc_volume_rewards(
     S: Dict[int, Dict[str, Dict[str, float]]],
     L: Dict[int, Dict[str, Dict[str, float]]],

--- a/df_py/volume/test/constants.py
+++ b/df_py/volume/test/constants.py
@@ -1,0 +1,19 @@
+# for shorter lines
+RATES = {"OCEAN": 0.5, "H2O": 1.6, "PSDN": 0.01}
+C1, C2, C3 = 7, 137, 1285  # chainIDs
+NA, NB, NC, ND = "0xnfta_addr", "0xnftb_addr", "0xnftc_addr", "0xnftd_addr"
+LP1, LP2, LP3, LP4 = "0xlp1_addr", "0xlp2_addr", "0xlp3_addr", "0xlp4_addr"
+LP5 = "0xlp4_addr"
+OCN_SYMB, H2O_SYMB = "OCEAN", "H2O"
+OCN_ADDR, H2O_ADDR = "0xocean", "0xh2o"
+OCN_ADDR2, H2O_ADDR2 = "0xocean2", "0xh2o2"
+SYMBOLS = {
+    C1: {OCN_ADDR: OCN_SYMB, H2O_ADDR: H2O_SYMB},
+    C2: {OCN_ADDR2: OCN_SYMB, H2O_ADDR2: H2O_SYMB},
+}
+APPROVED_TOKEN_ADDRS = {C1: [OCN_ADDR, H2O_ADDR], C2: [OCN_ADDR2, H2O_ADDR2]}
+
+# week 7 will make the DCV multiplier np.inf
+DF_WEEK = 7
+
+QUERY_PATH = "df_py.volume.reward_calculator.query_predictoor_contracts"

--- a/df_py/volume/test/helperfuncs.py
+++ b/df_py/volume/test/helperfuncs.py
@@ -1,0 +1,107 @@
+from typing import Dict, Union
+
+from enforce_typing import enforce_types
+
+from df_py.util.constants import ZERO_ADDRESS
+from df_py.volume.reward_calculator import RewardCalculator
+from df_py.volume.test.constants import *  # pylint: disable=wildcard-import
+
+
+@enforce_types
+def calc_rewards_C1(
+    stakes: Dict[int, Dict[str, Dict[str, float]]],
+    nftvols: Dict[int, Dict[str, Dict[str, float]]],
+    OCEAN_avail: float,
+    symbols: Dict[int, Dict[str, str]] = SYMBOLS,
+    rates: Dict[str, float] = RATES,
+    owners=None,
+    df_week: int = DF_WEEK,
+    do_pubrewards: bool = False,
+    do_rank: bool = False,
+):
+    rewards_per_lp, rewards_info = calc_rewards_(
+        stakes,
+        stakes,  # pass veOCEAN stakes as locked_amts for simplicity
+        nftvols,
+        OCEAN_avail,
+        symbols,
+        rates,
+        owners,
+        df_week,
+        do_pubrewards,
+        do_rank,
+    )
+    rewards_per_lp = {} if not rewards_per_lp else rewards_per_lp[C1]
+    rewards_info = {} if not rewards_info else rewards_info[C1]
+    return rewards_per_lp, rewards_info
+
+
+@enforce_types
+def calc_rewards_(
+    stakes: Dict[int, Dict[str, Dict[str, float]]],
+    locked_amts: Dict[int, Dict[str, Dict[str, float]]],
+    nftvols: Dict[int, Dict[str, Dict[str, float]]],
+    OCEAN_avail: float,
+    symbols: Dict[int, Dict[str, str]] = SYMBOLS,
+    rates: Dict[str, float] = RATES,
+    owners=None,
+    df_week: int = DF_WEEK,
+    do_pubrewards: bool = False,
+    do_rank: bool = False,
+):
+    """Helper. Fills in SYMBOLS, RATES, and DCV_multiplier for compactness"""
+    if owners is None:
+        owners = null_owners_(stakes, nftvols, symbols, rates)
+
+    calculator = RewardCalculator(
+        stakes,
+        locked_amts,
+        nftvols,
+        owners,
+        symbols,
+        rates,
+        df_week,
+        OCEAN_avail,
+        do_pubrewards,
+        do_rank,
+    )
+
+    return calculator.calculate()
+
+
+@enforce_types
+def null_owners_(
+    stakes: Dict[int, Dict[str, Dict[str, float]]],
+    nftvols: Dict[int, Dict[str, Dict[str, float]]],
+    symbols: Dict[int, Dict[str, str]],
+    rates: Dict[str, float],
+) -> Dict[int, Dict[str, Union[str, None]]]:
+    """
+    @return
+      owners -- dict of [chainID][nft_addr] : ZERO_ADDRESS
+    """
+    reward_calculator = RewardCalculator(
+        stakes, stakes, nftvols, {}, symbols, rates, DF_WEEK, False, False, False
+    )
+
+    chain_nft_tups = reward_calculator._get_chain_nft_tups()
+    return null_owners_from_chain_nft_tups(chain_nft_tups)
+
+
+@enforce_types
+def null_owners_from_chain_nft_tups(
+    chain_nft_tups,
+) -> Dict[int, Dict[str, Union[str, None]]]:
+    """
+    @arguments
+      chain_nft_tups -- list of (chainID, nft_addr), indexed by j
+    @return
+      owners -- dict of [chainID][nft_addr] : ZERO_ADDRESS
+    """
+    owners: Dict[int, Dict[str, Union[str, None]]] = {}
+    for chainID, nft_addr in chain_nft_tups:
+        if chainID not in owners:
+            owners[chainID] = {}
+        owners[chainID][nft_addr] = ZERO_ADDRESS
+
+    return owners

--- a/df_py/volume/test/test_calc_rewards_rank.py
+++ b/df_py/volume/test/test_calc_rewards_rank.py
@@ -1,0 +1,102 @@
+from typing import Tuple
+from unittest.mock import MagicMock, patch
+
+from enforce_typing import enforce_types
+import pytest
+
+from df_py.util.constants import MAX_N_RANK_ASSETS
+from df_py.volume.test.constants import *  # pylint: disable=wildcard-import
+from df_py.volume.test.helperfuncs import calc_rewards_C1
+
+
+@patch(QUERY_PATH, MagicMock(return_value={}))
+@enforce_types
+def test_rank_1_nft():
+    stakes = {C1: {NA: {LP1: 1000.0}}}
+    nftvols = {C1: {OCN_ADDR: {NA: 1.0}}}
+    OCEAN_avail = 10.0
+
+    rew, _ = calc_rewards_C1(stakes, nftvols, OCEAN_avail, do_rank=True)
+    assert rew == {LP1: 10.0}
+
+
+@patch(QUERY_PATH, MagicMock(return_value={}))
+@enforce_types
+def test_rank_3_nfts():
+    stakes = {C1: {NA: {LP1: 1000.0}, NB: {LP2: 1000.0}, NC: {LP3: 1000.0}}}
+    OCEAN_avail = 10.0
+
+    # equal volumes
+    nftvols = {C1: {OCN_ADDR: {NA: 1.0, NB: 1.0, NC: 1.0}}}
+    rew, _ = calc_rewards_C1(stakes, nftvols, OCEAN_avail, do_rank=True)
+    assert sorted(rew.keys()) == [LP1, LP2, LP3]
+    assert sum(rew.values()) == pytest.approx(10.0, 0.01)
+    for LP in [LP1, LP2, LP3]:
+        assert rew[LP] == pytest.approx(10.0 / 3.0)
+
+    # unequal volumes
+    nftvols = {C1: {OCN_ADDR: {NA: 1.0, NB: 0.002, NC: 0.001}}}
+    rew, _ = calc_rewards_C1(stakes, nftvols, OCEAN_avail, do_rank=True)
+    assert sorted(rew.keys()) == [LP1, LP2, LP3]
+    assert sum(rew.values()) == pytest.approx(10.0, 0.01)
+    assert rew[LP1] > rew[LP2] > rew[LP3], rew
+    assert rew[LP1] > 3.33, rew
+    assert rew[LP2] > 1.0, rew  # if it was pro-rata it would have been << 1.0
+    assert rew[LP3] > 1.0, rew  # ""
+
+
+@patch(QUERY_PATH, MagicMock(return_value={}))
+@enforce_types
+def test_rank_10_NFTs():
+    _test_rank_N_NFTs(10)
+
+
+@patch(QUERY_PATH, MagicMock(return_value={}))
+@enforce_types
+def test_rank_200_NFTs():
+    _test_rank_N_NFTs(200)
+
+
+@patch(QUERY_PATH, MagicMock(return_value={}))
+@enforce_types
+def _test_rank_N_NFTs(N: int):
+    OCEAN_avail = 10.0
+
+    # equal volumes
+    (_, LP_addrs, stakes, nftvols) = _rank_testvals(N, equal_vol=True)
+    rew, _ = calc_rewards_C1(stakes, nftvols, OCEAN_avail, do_rank=True)
+    assert len(rew) == N
+    assert LP_addrs == sorted(rew.keys())
+    assert sum(rew.values()) == pytest.approx(10.0, 0.01)
+    assert min(rew.values()) == max(rew.values())
+
+    # unequal volumes
+    (_, LP_addrs, stakes, nftvols) = _rank_testvals(N, equal_vol=False)
+    rew, _ = calc_rewards_C1(stakes, nftvols, OCEAN_avail, do_rank=True)
+    max_N = min(N, MAX_N_RANK_ASSETS)
+    assert len(rew) == max_N
+    assert LP_addrs[:max_N] == sorted(rew.keys())
+    assert sum(rew.values()) == pytest.approx(10.0, 0.01)
+    assert min(rew.values()) > 0.0
+    for i in range(1, N):
+        if i >= max_N:
+            # if reward is zero, then it shouldn't even show up in rewards dict
+            assert LP_addrs[i] not in rew
+        else:
+            assert rew[LP_addrs[i]] < rew[LP_addrs[i - 1]]
+
+
+@enforce_types
+def _rank_testvals(N: int, equal_vol: bool) -> Tuple[list, list, dict, dict]:
+    NFT_addrs = [f"0xnft_{i:03}" for i in range(N)]
+    LP_addrs = [f"0xlp_{i:03}" for i in range(N)]
+    stakes: dict = {C1: {}}
+    nftvols: dict = {C1: {OCN_ADDR: {}}}
+    for i, (NFT_addr, LP_addr) in enumerate(zip(NFT_addrs, LP_addrs)):
+        stakes[C1][NFT_addr] = {LP_addr: 1000.0}
+        if equal_vol:
+            vol = 1.0
+        else:
+            vol = max(N, 1000.0) - float(i)
+        nftvols[C1][OCN_ADDR][NFT_addr] = vol
+    return (NFT_addrs, LP_addrs, stakes, nftvols)


### PR DESCRIPTION
Towards #812

Carve out functionality from reward_calculator.py, and move it into
- df_py/util/dcv_multiplier.py 
- df_py/util/reward_shaper.py

Also, split apart test_calc_rewards.py into:
- df_py/util/test/test_dcv_multiplier.py
- df_py/util/test/test_reward_shaper.py
- df_py/volume/test/constants.py
- df_py/volume/test/helperfuncs.py
- df_py/volume/test/test_calc_rewards_rank.py
