### PR TITLE
Run checkpoint_feedist.yml Sunday night

### DIFF
--- a/.github/workflows/checkpoint_feedist.yml
+++ b/.github/workflows/checkpoint_feedist.yml
@@ -3,7 +3,7 @@ name: Checkpoint FeeDistributor
 on:
   schedule:
     - cron: "0 0 * * 4"
-    - cron: "10 0 * * 5"
+    - cron: "10 1 * * 0"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The current setup is set to run the checkpoint every Friday morning

But, with vestingB releasing tokens Sunday at 00:00 GMT, we need to run this flow after the transfer

